### PR TITLE
feat: 为文字独轮车与收藏夹增加发送模式，并修复收藏夹焦点发送问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -95,7 +95,9 @@ new MutationObserver((_mutationsList, observer) => {
     }
 }).observe(document.body, { childList: true, subtree: true })
 // n-config-provider 的 preflight-style-disabled 属性不知道为什么不生效，只能这样了
-GM_addStyle('body { font-size: 12px }')
+GM_addStyle(`
+body { font-size: 12px }
+`)
 </script>
 
 <template>

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -80,6 +80,14 @@ const handleTabsClose = (name: number) => {
         })
     }
 }
+
+const isSendingPanel = (panelName: number) => {
+    return (
+        moduleStore.moduleConfig.Favorites.enable &&
+        moduleStore.moduleConfig.Favorites.sendingTabName === panelName
+    )
+}
+
 const handleStartSpamer = () => {
     const currentPanel = moduleStore.moduleConfig.Favorites.favoritesTabPanels.find(
         (panel) => panel.name === moduleStore.moduleConfig.Favorites.favoritesTabsValue
@@ -99,6 +107,7 @@ const handleStartSpamer = () => {
         message.error('没参数你车什么?')
     } else {
         uiStore.uiConfig.isShowPanel = false
+        moduleStore.moduleConfig.Favorites.sendingTabName = currentPanel.name
         moduleStore.moduleConfig.Favorites.enable = true
         moduleStore.emitter.emit('Favorites', {
             module: 'Favorites'
@@ -137,7 +146,7 @@ const toggleSequentialMode = () => {
 </script>
 
 <template>
-    <n-form :rules="rules" :disabled="moduleStore.moduleConfig.Favorites.enable">
+    <n-form :rules="rules">
         <n-page-header
             subtitle="收藏夹：这是一个收藏夹，当然你也可以车收藏夹😊"
             style="margin-bottom: 10px"
@@ -150,6 +159,7 @@ const toggleSequentialMode = () => {
                             <n-input-number
                                 clearable
                                 :show-button="false"
+                                :disabled="moduleStore.moduleConfig.Favorites.enable"
                                 v-model:value="moduleStore.moduleConfig.Favorites.timeinterval"
                                 placeholder="默认5，单位为秒"
                                 min="1"
@@ -231,6 +241,7 @@ const toggleSequentialMode = () => {
                     >
                         <n-input
                             v-model:value="panels.tab"
+                            :disabled="isSendingPanel(panels.name)"
                             clearable
                             placeholder="最好写一下标题吧"
                         />
@@ -242,6 +253,7 @@ const toggleSequentialMode = () => {
                     >
                         <n-input
                             v-model:value="panels.msg"
+                            :disabled="isSendingPanel(panels.name)"
                             round
                             clearable
                             show-count
@@ -271,4 +283,3 @@ const toggleSequentialMode = () => {
         </n-flex>
     </n-form>
 </template>
-

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -11,6 +11,8 @@ import {
     NTabPane,
     NButton,
     NPageHeader,
+    NIcon,
+    NAvatar,
     useMessage,
     useDialog
 } from 'naive-ui'
@@ -18,10 +20,13 @@ import type { InputInst } from 'naive-ui'
 import _ from 'lodash'
 import { useModuleStore } from '@/stores/useModuleStore'
 import { useUIStore } from '@/stores/useUIStore'
+import { useBiliStore } from '@/stores/useBiliStore'
+import EmotionIcon from '@/assets/EmotionIcon.svg?component'
 import stop from '@/modules/Spamer/textSpamer'
 
 const moduleStore = useModuleStore()
 const uiStore = useUIStore()
+const biliStore = useBiliStore()
 const message = useMessage()
 const dialog = useDialog()
 const favStop = new stop('StopFavoritesSpamer')
@@ -432,7 +437,7 @@ const toggleSequentialMode = () => {
             subtitle="收藏夹：这是一个收藏夹，当然你也可以车收藏夹😊"
             style="margin-bottom: 10px"
         />
-        <n-form-item :show-label="false">
+        <n-form-item :show-label="false" :show-feedback="false">
             <n-flex>
                 <n-form-item label="时间间隔" path="timeinterval">
                     <n-popover trigger="hover" style="max-width: 300px" placement="bottom">
@@ -493,9 +498,6 @@ const toggleSequentialMode = () => {
                 >
                     按顺序发送 {{ moduleStore.moduleConfig.Favorites.sequentialMode ? '开' : '关' }}
                 </button>
-                <span style="font-size: 12px; color: #909399"
-                    >提示：运行中修改开关不会立即生效，下次点击“开车”生效</span
-                >
             </n-flex>
         </n-form-item>
 
@@ -532,63 +534,101 @@ const toggleSequentialMode = () => {
                         show-require-mark
                         :validation-status="panels.msg === '' ? 'error' : undefined"
                     >
-                        <div style="width: 100%">
-                            <n-input
-                                :ref="(inst) => setMainInputRef(panels.name, inst as InputInst | null)"
-                                v-model:value="panels.msg"
-                                :disabled="isSendingPanel(panels.name)"
-                                round
-                                clearable
-                                show-count
-                                type="textarea"
-                                placeholder="默认每次弹幕发送字数为你文字独轮车设置的间隔，超出相应值将自动分割到下一条弹幕"
-                            />
+                        <n-flex align="flex-start" :wrap="false" style="width: 100%; gap: 8px">
+                            <div style="width: 100%">
+                                <n-input
+                                    :ref="(inst) => setMainInputRef(panels.name, inst as InputInst | null)"
+                                    v-model:value="panels.msg"
+                                    :disabled="isSendingPanel(panels.name)"
+                                    round
+                                    clearable
+                                    show-count
+                                    type="textarea"
+                                    placeholder="默认每次弹幕发送字数为你文字独轮车设置的间隔，超出相应值将自动分割到下一条弹幕"
+                                />
 
-                            <div
-                                v-if="
-                                    !moduleStore.moduleConfig.Favorites.storytellerMode &&
-                                    panels.name === moduleStore.moduleConfig.Favorites.favoritesTabsValue
-                                "
-                                class="preview-wrap"
-                            >
-                                <div class="preview-title">
-                                    超长灰显预览（超过数量间隔的部分会被丢弃）
-                                </div>
-                                <div class="preview-overlay-wrap">
-                                    <n-input
-                                        :ref="(inst) => setPreviewInputRef(panels.name, inst as InputInst | null)"
-                                        round
-                                        type="textarea"
-                                        readonly
-                                        :show-count="true"
-                                        :value="panels.msg"
-                                        class="preview-base"
-                                    />
-                                    <div
-                                        class="preview-overlay-viewport"
-                                        :style="favoritesOverlayViewportStyles[panels.name] || {}"
-                                        aria-hidden="true"
-                                    >
+                                <div
+                                    v-if="
+                                        !moduleStore.moduleConfig.Favorites.storytellerMode &&
+                                        panels.name === moduleStore.moduleConfig.Favorites.favoritesTabsValue
+                                    "
+                                    class="preview-wrap"
+                                >
+                                    <div class="preview-title">
+                                        逐行发送模式预览 - 灰色文字代表超过本行字数上限会被自动舍弃
+                                    </div>
+                                    <div class="preview-overlay-wrap">
+                                        <n-input
+                                            :ref="(inst) =>
+                                                setPreviewInputRef(panels.name, inst as InputInst | null)
+                                            "
+                                            round
+                                            type="textarea"
+                                            readonly
+                                            :show-count="true"
+                                            :value="panels.msg"
+                                            class="preview-base"
+                                        />
                                         <div
-                                            :ref="(el) => setOverlayElement(panels.name, el)"
-                                            class="preview-overlay"
-                                            :style="{
-                                                ...(favoritesOverlayStyles[panels.name] || {})
-                                            }"
+                                            class="preview-overlay-viewport"
+                                            :style="favoritesOverlayViewportStyles[panels.name] || {}"
+                                            aria-hidden="true"
                                         >
                                             <div
-                                                class="preview-line"
-                                                v-for="(line, idx) in getPreviewLines(panels.msg)"
-                                                :key="`${panels.name}-${idx}`"
+                                                :ref="(el) => setOverlayElement(panels.name, el)"
+                                                class="preview-overlay"
+                                                :style="{
+                                                    ...(favoritesOverlayStyles[panels.name] || {})
+                                                }"
                                             >
-                                                <span>{{ line.keep }}</span
-                                                ><span class="overflow">{{ line.overflow }}</span>
+                                                <div
+                                                    class="preview-line"
+                                                    v-for="(line, idx) in getPreviewLines(panels.msg)"
+                                                    :key="`${panels.name}-${idx}`"
+                                                >
+                                                    <span>{{ line.keep }}</span
+                                                    ><span class="overflow">{{ line.overflow }}</span>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
+
+                            <n-popover trigger="click" placement="left" style="width: 500px">
+                                <template #trigger>
+                                    <n-button text class="emoji-trigger" :disabled="isSendingPanel(panels.name)">
+                                        <n-icon :size="24">
+                                            <EmotionIcon />
+                                        </n-icon>
+                                    </n-button>
+                                </template>
+                                <div
+                                    style="
+                                        display: grid;
+                                        grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+                                        gap: 8px;
+                                        padding: 8px;
+                                    "
+                                >
+                                    <div
+                                        v-for="data in biliStore.emotionData.find((data) => data.pkg_id === 100)
+                                            ?.emoticons"
+                                        :key="data.emoticon_id"
+                                        :disabled="data.perm === 0"
+                                    >
+                                        <n-avatar
+                                            :color="uiStore.uiConfig.theme === 'dark' ? '#48484E' : 'white'"
+                                            :size="24"
+                                            :src="data.url"
+                                            object-fit="contain"
+                                            style="cursor: pointer"
+                                            @click="panels.msg += data.emoji"
+                                        />
+                                    </div>
+                                </div>
+                            </n-popover>
+                        </n-flex>
                     </n-form-item>
                 </n-tab-pane>
             </n-tabs>
@@ -663,5 +703,10 @@ const toggleSequentialMode = () => {
 
 .overflow {
     color: #b5b5b5;
+}
+
+.emoji-trigger {
+    padding-left: 4px;
+    margin-top: 2px;
 }
 </style>

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -669,7 +669,7 @@ const toggleSequentialMode = () => {
                                     class="preview-wrap"
                                 >
                                     <div class="preview-title">
-                                        逐行发送模式预览 - 灰色文字代表超过本行字数上限会被自动舍弃
+                                        逐行发送模式预览 - 橙色文字代表超过本行字数上限会被自动舍弃
                                     </div>
                                     <div class="preview-overlay-wrap">
                                         <n-input
@@ -816,7 +816,7 @@ const toggleSequentialMode = () => {
 }
 
 .overflow {
-    color: #b5b5b5;
+    color: #f47a4d;
 }
 
 .emoji-trigger {

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -35,11 +35,13 @@ const favoritesMainInputRefs = ref<Record<number, InputInst | null>>({})
 const favoritesPreviewInputRefs = ref<Record<number, InputInst | null>>({})
 const favoritesOverlayStyles = ref<Record<number, Record<string, string>>>({})
 const favoritesOverlayViewportStyles = ref<Record<number, Record<string, string>>>({})
+const favoritesSelectionRanges = ref<Record<number, { start: number; end: number }>>({})
 
 const favoritesMainTextareas = new Map<number, HTMLTextAreaElement>()
 const favoritesPreviewTextareas = new Map<number, HTMLTextAreaElement>()
 const favoritesMainListeners = new Map<number, (event: Event) => void>()
 const favoritesPreviewListeners = new Map<number, (event: Event) => void>()
+const favoritesCursorListeners = new Map<number, (event: Event) => void>()
 const favoritesOverlayElements = new Map<number, HTMLDivElement>()
 const favoritesSyncing = new Set<number>()
 let favoritesRelayoutTimer: ReturnType<typeof setTimeout> | null = null
@@ -165,6 +167,48 @@ const syncPreviewToMain = (event: Event, panelName: number) => {
     })
 }
 
+const updateFavoriteSelectionRange = (panelName: number, event?: Event) => {
+    const target =
+        (event?.target as HTMLTextAreaElement | null) ?? favoritesMainTextareas.get(panelName) ?? null
+    if (!target) return
+
+    const maxLength = target.value.length
+    const rawStart = target.selectionStart ?? maxLength
+    const rawEnd = target.selectionEnd ?? rawStart
+    const start = Math.max(0, Math.min(rawStart, maxLength))
+    const end = Math.max(start, Math.min(rawEnd, maxLength))
+    favoritesSelectionRanges.value[panelName] = { start, end }
+}
+
+const insertEmojiToFavorite = (panelName: number, emoji: string) => {
+    const panel = moduleStore.moduleConfig.Favorites.favoritesTabPanels.find((item) => item.name === panelName)
+    if (!panel) return
+
+    const text = panel.msg || ''
+    const activeTextarea = favoritesMainTextareas.get(panelName) ?? null
+    const activeRange =
+        activeTextarea && document.activeElement === activeTextarea
+            ? {
+                  start: activeTextarea.selectionStart ?? text.length,
+                  end: activeTextarea.selectionEnd ?? text.length
+              }
+            : null
+    const range = activeRange ?? favoritesSelectionRanges.value[panelName] ?? { start: text.length, end: text.length }
+    const start = Math.max(0, Math.min(range.start, text.length))
+    const end = Math.max(start, Math.min(range.end, text.length))
+
+    panel.msg = `${text.slice(0, start)}${emoji}${text.slice(end)}`
+    const cursor = start + emoji.length
+    favoritesSelectionRanges.value[panelName] = { start: cursor, end: cursor }
+
+    nextTick(() => {
+        const textarea = favoritesMainTextareas.get(panelName)
+        if (!textarea) return
+        textarea.focus()
+        textarea.setSelectionRange(cursor, cursor)
+    })
+}
+
 const bindPanelScroll = (panelName: number) => {
     const main = favoritesMainInputRefs.value[panelName]?.textareaElRef ?? null
     const preview = favoritesPreviewInputRefs.value[panelName]?.textareaElRef ?? null
@@ -172,17 +216,34 @@ const bindPanelScroll = (panelName: number) => {
     const currentMain = favoritesMainTextareas.get(panelName) ?? null
     if (main !== currentMain) {
         const oldMainListener = favoritesMainListeners.get(panelName)
+        const oldCursorListener = favoritesCursorListeners.get(panelName)
         if (currentMain && oldMainListener) {
             currentMain.removeEventListener('scroll', oldMainListener)
         }
+        if (currentMain && oldCursorListener) {
+            currentMain.removeEventListener('click', oldCursorListener)
+            currentMain.removeEventListener('keyup', oldCursorListener)
+            currentMain.removeEventListener('select', oldCursorListener)
+            currentMain.removeEventListener('input', oldCursorListener)
+            currentMain.removeEventListener('blur', oldCursorListener)
+        }
         favoritesMainTextareas.delete(panelName)
         favoritesMainListeners.delete(panelName)
+        favoritesCursorListeners.delete(panelName)
 
         if (main) {
             const listener = (event: Event) => syncMainToPreview(event, panelName)
+            const cursorListener = (event: Event) => updateFavoriteSelectionRange(panelName, event)
             main.addEventListener('scroll', listener, { passive: true })
+            main.addEventListener('click', cursorListener, { passive: true })
+            main.addEventListener('keyup', cursorListener, { passive: true })
+            main.addEventListener('select', cursorListener, { passive: true })
+            main.addEventListener('input', cursorListener, { passive: true })
+            main.addEventListener('blur', cursorListener, { passive: true })
             favoritesMainTextareas.set(panelName, main)
             favoritesMainListeners.set(panelName, listener)
+            favoritesCursorListeners.set(panelName, cursorListener)
+            updateFavoriteSelectionRange(panelName)
         }
     }
 
@@ -299,8 +360,16 @@ watch(
 onBeforeUnmount(() => {
     favoritesMainTextareas.forEach((textarea, panelName) => {
         const listener = favoritesMainListeners.get(panelName)
+        const cursorListener = favoritesCursorListeners.get(panelName)
         if (listener) {
             textarea.removeEventListener('scroll', listener)
+        }
+        if (cursorListener) {
+            textarea.removeEventListener('click', cursorListener)
+            textarea.removeEventListener('keyup', cursorListener)
+            textarea.removeEventListener('select', cursorListener)
+            textarea.removeEventListener('input', cursorListener)
+            textarea.removeEventListener('blur', cursorListener)
         }
     })
 
@@ -358,7 +427,32 @@ const handleTabsClose = (name: number) => {
             positiveText: '确定',
             negativeText: '再想想',
             onPositiveClick: () => {
+                const mainTextarea = favoritesMainTextareas.get(name)
+                const mainListener = favoritesMainListeners.get(name)
+                const cursorListener = favoritesCursorListeners.get(name)
+                const previewTextarea = favoritesPreviewTextareas.get(name)
+                const previewListener = favoritesPreviewListeners.get(name)
+                if (mainTextarea && mainListener) {
+                    mainTextarea.removeEventListener('scroll', mainListener)
+                }
+                if (mainTextarea && cursorListener) {
+                    mainTextarea.removeEventListener('click', cursorListener)
+                    mainTextarea.removeEventListener('keyup', cursorListener)
+                    mainTextarea.removeEventListener('select', cursorListener)
+                    mainTextarea.removeEventListener('input', cursorListener)
+                    mainTextarea.removeEventListener('blur', cursorListener)
+                }
+                if (previewTextarea && previewListener) {
+                    previewTextarea.removeEventListener('scroll', previewListener)
+                }
                 _.remove(moduleStore.moduleConfig.Favorites.favoritesTabPanels, { name })
+                delete favoritesSelectionRanges.value[name]
+                favoritesMainListeners.delete(name)
+                favoritesPreviewListeners.delete(name)
+                favoritesCursorListeners.delete(name)
+                favoritesMainTextareas.delete(name)
+                favoritesPreviewTextareas.delete(name)
+                favoritesOverlayElements.delete(name)
                 moduleStore.moduleConfig.Favorites.favoritesTabsValue = name - 1
             }
         })
@@ -623,7 +717,7 @@ const toggleSequentialMode = () => {
                                             :src="data.url"
                                             object-fit="contain"
                                             style="cursor: pointer"
-                                            @click="panels.msg += data.emoji"
+                                            @click="insertEmojiToFavorite(panels.name, data.emoji)"
                                         />
                                     </div>
                                 </div>

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -121,6 +121,16 @@ const handleSendToText = () => {
         message.error('未找到当前标签页')
     }
 }
+
+const toggleStorytellerMode = () => {
+    moduleStore.moduleConfig.Favorites.storytellerMode =
+        !moduleStore.moduleConfig.Favorites.storytellerMode
+}
+
+const toggleSequentialMode = () => {
+    moduleStore.moduleConfig.Favorites.sequentialMode =
+        !moduleStore.moduleConfig.Favorites.sequentialMode
+}
 </script>
 
 <template>
@@ -152,6 +162,49 @@ const handleSendToText = () => {
                 </n-form-item>
             </n-flex>
         </n-form-item>
+
+        <n-form-item :show-label="false">
+            <n-flex align="center" style="gap: 8px; width: 100%">
+                <button
+                    type="button"
+                    :disabled="moduleStore.moduleConfig.Favorites.enable"
+                    @click="toggleStorytellerMode"
+                    :style="{
+                        padding: '4px 10px',
+                        borderRadius: '999px',
+                        border: '1px solid #bfbfbf',
+                        cursor: moduleStore.moduleConfig.Favorites.enable ? 'not-allowed' : 'pointer',
+                        color: moduleStore.moduleConfig.Favorites.storytellerMode ? '#fff' : '#333',
+                        backgroundColor: moduleStore.moduleConfig.Favorites.storytellerMode
+                            ? '#18a058'
+                            : '#fff'
+                    }"
+                >
+                    说书模式 {{ moduleStore.moduleConfig.Favorites.storytellerMode ? '开' : '关' }}
+                </button>
+                <button
+                    type="button"
+                    :disabled="moduleStore.moduleConfig.Favorites.enable"
+                    @click="toggleSequentialMode"
+                    :style="{
+                        padding: '4px 10px',
+                        borderRadius: '999px',
+                        border: '1px solid #bfbfbf',
+                        cursor: moduleStore.moduleConfig.Favorites.enable ? 'not-allowed' : 'pointer',
+                        color: moduleStore.moduleConfig.Favorites.sequentialMode ? '#fff' : '#333',
+                        backgroundColor: moduleStore.moduleConfig.Favorites.sequentialMode
+                            ? '#18a058'
+                            : '#fff'
+                    }"
+                >
+                    按顺序发送 {{ moduleStore.moduleConfig.Favorites.sequentialMode ? '开' : '关' }}
+                </button>
+                <span style="font-size: 12px; color: #909399"
+                    >提示：运行中修改开关不会立即生效，下次点击“开车”生效</span
+                >
+            </n-flex>
+        </n-form-item>
+
         <n-form-item :show-feedback="false" :show-label="false">
             <n-tabs
                 type="card"

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, nextTick, onMounted, onUpdated, onBeforeUnmount } from 'vue'
+import { computed, ref, nextTick, onMounted, onBeforeUnmount, watch } from 'vue'
 import {
     NForm,
     NFormItem,
@@ -30,13 +30,14 @@ const favoritesMainInputRefs = ref<Record<number, InputInst | null>>({})
 const favoritesPreviewInputRefs = ref<Record<number, InputInst | null>>({})
 const favoritesOverlayStyles = ref<Record<number, Record<string, string>>>({})
 const favoritesOverlayViewportStyles = ref<Record<number, Record<string, string>>>({})
-const favoritesOverlayTransforms = ref<Record<number, string>>({})
 
 const favoritesMainTextareas = new Map<number, HTMLTextAreaElement>()
 const favoritesPreviewTextareas = new Map<number, HTMLTextAreaElement>()
 const favoritesMainListeners = new Map<number, (event: Event) => void>()
 const favoritesPreviewListeners = new Map<number, (event: Event) => void>()
+const favoritesOverlayElements = new Map<number, HTMLDivElement>()
 const favoritesSyncing = new Set<number>()
+let favoritesRelayoutTimer: ReturnType<typeof setTimeout> | null = null
 
 const rules = {
     timeinterval: {
@@ -61,8 +62,34 @@ const getPreviewLines = (msg: string) => {
     }))
 }
 
+const getOffsetToAncestor = (el: HTMLElement, ancestor: HTMLElement) => {
+    let top = 0
+    let left = 0
+    let current: HTMLElement | null = el
+
+    while (current && current !== ancestor) {
+        top += current.offsetTop
+        left += current.offsetLeft
+        current = current.offsetParent as HTMLElement | null
+    }
+
+    if (current !== ancestor) {
+        const hostRect = ancestor.getBoundingClientRect()
+        const elRect = el.getBoundingClientRect()
+        return {
+            top: elRect.top - hostRect.top,
+            left: elRect.left - hostRect.left
+        }
+    }
+
+    return { top, left }
+}
+
 const setOverlayTransform = (panelName: number, scrollTop: number) => {
-    favoritesOverlayTransforms.value[panelName] = `translateY(${-scrollTop}px)`
+    const overlay = favoritesOverlayElements.get(panelName)
+    if (overlay) {
+        overlay.style.transform = `translateY(${-scrollTop}px)`
+    }
 }
 
 const updateOverlayStyle = (panelName: number) => {
@@ -79,15 +106,17 @@ const updateOverlayStyle = (panelName: number) => {
     const suffixHeight = suffix?.offsetHeight ?? 0
 
     const previewHost = previewWrapper.closest('.preview-overlay-wrap') as HTMLElement | null
-    if (previewHost) {
-        const hostRect = previewHost.getBoundingClientRect()
-        const textareaRect = previewTextarea.getBoundingClientRect()
-        favoritesOverlayViewportStyles.value[panelName] = {
-            top: `${textareaRect.top - hostRect.top}px`,
-            left: `${textareaRect.left - hostRect.left}px`,
-            width: `${textareaRect.width}px`,
-            height: `${textareaRect.height}px`
-        }
+    if (!previewHost) return
+    const { top, left } = getOffsetToAncestor(previewTextarea, previewHost)
+    const width = previewTextarea.offsetWidth
+    const height = previewTextarea.offsetHeight
+    if (width <= 1 || height <= 1) return
+
+    favoritesOverlayViewportStyles.value[panelName] = {
+        top: `${top}px`,
+        left: `${left}px`,
+        width: `${width}px`,
+        height: `${height}px`
     }
 
     favoritesOverlayStyles.value[panelName] = {
@@ -188,19 +217,79 @@ const setPreviewInputRef = (panelName: number, inst: InputInst | null) => {
     bindPanelScroll(panelName)
 }
 
-onMounted(() => {
+const setOverlayElement = (panelName: number, el: Element | null) => {
+    if (el instanceof HTMLDivElement) {
+        favoritesOverlayElements.set(panelName, el)
+        const mainScrollTop = favoritesMainTextareas.get(panelName)?.scrollTop ?? 0
+        setOverlayTransform(panelName, mainScrollTop)
+    } else {
+        favoritesOverlayElements.delete(panelName)
+    }
+}
+
+const bindActivePanelScroll = () => {
+    const activePanelName = moduleStore.moduleConfig.Favorites.favoritesTabsValue
+    bindPanelScroll(activePanelName)
+}
+
+const scheduleFavoritesRelayout = () => {
+    if (favoritesRelayoutTimer) {
+        clearTimeout(favoritesRelayoutTimer)
+        favoritesRelayoutTimer = null
+    }
+
     nextTick(() => {
-        moduleStore.moduleConfig.Favorites.favoritesTabPanels.forEach((panel) => {
-            bindPanelScroll(panel.name)
-        })
+        bindActivePanelScroll()
+        requestAnimationFrame(() => bindActivePanelScroll())
+        favoritesRelayoutTimer = setTimeout(() => {
+            bindActivePanelScroll()
+            favoritesRelayoutTimer = null
+        }, 360)
     })
+}
+
+onMounted(() => {
+    scheduleFavoritesRelayout()
 })
 
-onUpdated(() => {
-    moduleStore.moduleConfig.Favorites.favoritesTabPanels.forEach((panel) => {
-        bindPanelScroll(panel.name)
-    })
-})
+watch(
+    () => moduleStore.moduleConfig.Favorites.favoritesTabsValue,
+    () => {
+        scheduleFavoritesRelayout()
+    }
+)
+
+watch(
+    () => moduleStore.moduleConfig.Favorites.storytellerMode,
+    () => {
+        scheduleFavoritesRelayout()
+    }
+)
+
+watch(
+    () => moduleStore.moduleConfig.Favorites.favoritesTabPanels.length,
+    () => {
+        scheduleFavoritesRelayout()
+    }
+)
+
+watch(
+    () => uiStore.uiConfig.isShowPanel,
+    (show) => {
+        if (show && uiStore.uiConfig.activeMenuIndex === 'FavoritesView') {
+            scheduleFavoritesRelayout()
+        }
+    }
+)
+
+watch(
+    () => uiStore.uiConfig.activeMenuIndex,
+    (menu) => {
+        if (menu === 'FavoritesView' && uiStore.uiConfig.isShowPanel) {
+            scheduleFavoritesRelayout()
+        }
+    }
+)
 
 onBeforeUnmount(() => {
     favoritesMainTextareas.forEach((textarea, panelName) => {
@@ -216,6 +305,10 @@ onBeforeUnmount(() => {
             textarea.removeEventListener('scroll', listener)
         }
     })
+    if (favoritesRelayoutTimer) {
+        clearTimeout(favoritesRelayoutTimer)
+        favoritesRelayoutTimer = null
+    }
 })
 
 const handleTabsValueUpdate = (value: number) => {
@@ -451,7 +544,13 @@ const toggleSequentialMode = () => {
                                 placeholder="默认每次弹幕发送字数为你文字独轮车设置的间隔，超出相应值将自动分割到下一条弹幕"
                             />
 
-                            <div v-if="!moduleStore.moduleConfig.Favorites.storytellerMode" class="preview-wrap">
+                            <div
+                                v-if="
+                                    !moduleStore.moduleConfig.Favorites.storytellerMode &&
+                                    panels.name === moduleStore.moduleConfig.Favorites.favoritesTabsValue
+                                "
+                                class="preview-wrap"
+                            >
                                 <div class="preview-title">
                                     超长灰显预览（超过数量间隔的部分会被丢弃）
                                 </div>
@@ -471,12 +570,10 @@ const toggleSequentialMode = () => {
                                         aria-hidden="true"
                                     >
                                         <div
+                                            :ref="(el) => setOverlayElement(panels.name, el)"
                                             class="preview-overlay"
                                             :style="{
-                                                ...(favoritesOverlayStyles[panels.name] || {}),
-                                                transform:
-                                                    favoritesOverlayTransforms[panels.name] ||
-                                                    'translateY(0px)'
+                                                ...(favoritesOverlayStyles[panels.name] || {})
                                             }"
                                         >
                                             <div

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -437,7 +437,7 @@ const toggleSequentialMode = () => {
             subtitle="收藏夹：这是一个收藏夹，当然你也可以车收藏夹😊"
             style="margin-bottom: 10px"
         />
-        <n-form-item :show-label="false" :show-feedback="false">
+        <n-form-item :show-label="false">
             <n-flex>
                 <n-form-item label="时间间隔" path="timeinterval">
                     <n-popover trigger="hover" style="max-width: 300px" placement="bottom">
@@ -462,7 +462,7 @@ const toggleSequentialMode = () => {
             </n-flex>
         </n-form-item>
 
-        <n-form-item :show-label="false">
+        <n-form-item label="模式选择">
             <n-flex align="center" style="gap: 8px; width: 100%">
                 <button
                     type="button"

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -92,6 +92,26 @@ const getOffsetToAncestor = (el: HTMLElement, ancestor: HTMLElement) => {
     return { top, left }
 }
 
+const isSameStyleRecord = (
+    current: Record<string, string>,
+    next: Record<string, string>
+) => {
+    const currentKeys = Object.keys(current)
+    const nextKeys = Object.keys(next)
+    if (currentKeys.length !== nextKeys.length) return false
+    return nextKeys.every((key) => current[key] === next[key])
+}
+
+const setPanelStyleIfChanged = (
+    styleRef: { value: Record<number, Record<string, string>> },
+    panelName: number,
+    nextStyle: Record<string, string>
+) => {
+    const currentStyle = styleRef.value[panelName]
+    if (currentStyle && isSameStyleRecord(currentStyle, nextStyle)) return
+    styleRef.value[panelName] = nextStyle
+}
+
 const setOverlayTransform = (panelName: number, scrollTop: number) => {
     const overlay = favoritesOverlayElements.get(panelName)
     if (overlay) {
@@ -119,14 +139,14 @@ const updateOverlayStyle = (panelName: number) => {
     const height = previewTextarea.offsetHeight
     if (width <= 1 || height <= 1) return
 
-    favoritesOverlayViewportStyles.value[panelName] = {
+    setPanelStyleIfChanged(favoritesOverlayViewportStyles, panelName, {
         top: `${top}px`,
         left: `${left}px`,
         width: `${width}px`,
         height: `${height}px`
-    }
+    })
 
-    favoritesOverlayStyles.value[panelName] = {
+    setPanelStyleIfChanged(favoritesOverlayStyles, panelName, {
         fontSize: style.fontSize,
         lineHeight: style.lineHeight,
         fontFamily: style.fontFamily,
@@ -136,7 +156,7 @@ const updateOverlayStyle = (panelName: number) => {
         paddingBottom: `calc(${style.paddingBottom} + ${suffixHeight}px)`,
         paddingLeft: style.paddingLeft,
         boxSizing: 'border-box'
-    }
+    })
 }
 
 const syncMainToPreview = (event: Event, panelName: number) => {

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, nextTick, onMounted, onUpdated, onBeforeUnmount } from 'vue'
 import {
     NForm,
     NFormItem,
@@ -14,6 +14,7 @@ import {
     useMessage,
     useDialog
 } from 'naive-ui'
+import type { InputInst } from 'naive-ui'
 import _ from 'lodash'
 import { useModuleStore } from '@/stores/useModuleStore'
 import { useUIStore } from '@/stores/useUIStore'
@@ -25,6 +26,18 @@ const message = useMessage()
 const dialog = useDialog()
 const favStop = new stop('StopFavoritesSpamer')
 
+const favoritesMainInputRefs = ref<Record<number, InputInst | null>>({})
+const favoritesPreviewInputRefs = ref<Record<number, InputInst | null>>({})
+const favoritesOverlayStyles = ref<Record<number, Record<string, string>>>({})
+const favoritesOverlayViewportStyles = ref<Record<number, Record<string, string>>>({})
+const favoritesOverlayTransforms = ref<Record<number, string>>({})
+
+const favoritesMainTextareas = new Map<number, HTMLTextAreaElement>()
+const favoritesPreviewTextareas = new Map<number, HTMLTextAreaElement>()
+const favoritesMainListeners = new Map<number, (event: Event) => void>()
+const favoritesPreviewListeners = new Map<number, (event: Event) => void>()
+const favoritesSyncing = new Set<number>()
+
 const rules = {
     timeinterval: {
         required: true,
@@ -35,12 +48,184 @@ const rules = {
         }
     }
 }
+
+const textintervalForPreview = computed(() => {
+    return Math.max(1, Number(moduleStore.moduleConfig.TextSpam.textinterval || 1))
+})
+
+const getPreviewLines = (msg: string) => {
+    const textinterval = textintervalForPreview.value
+    return msg.split(/\r?\n/).map((line) => ({
+        keep: line.slice(0, textinterval),
+        overflow: line.slice(textinterval)
+    }))
+}
+
+const setOverlayTransform = (panelName: number, scrollTop: number) => {
+    favoritesOverlayTransforms.value[panelName] = `translateY(${-scrollTop}px)`
+}
+
+const updateOverlayStyle = (panelName: number) => {
+    const mainTextarea = favoritesMainInputRefs.value[panelName]?.textareaElRef
+    const mainWrapper = favoritesMainInputRefs.value[panelName]?.wrapperElRef
+    const previewTextarea = favoritesPreviewInputRefs.value[panelName]?.textareaElRef
+    const previewWrapper = favoritesPreviewInputRefs.value[panelName]?.wrapperElRef
+
+    if (!mainTextarea || !mainWrapper || !previewTextarea || !previewWrapper) return
+
+    const style = getComputedStyle(mainTextarea)
+    const suffix = mainWrapper.querySelector('.n-input__suffix') as HTMLElement | null
+    const suffixWidth = suffix?.offsetWidth ?? 0
+    const suffixHeight = suffix?.offsetHeight ?? 0
+
+    const previewHost = previewWrapper.closest('.preview-overlay-wrap') as HTMLElement | null
+    if (previewHost) {
+        const hostRect = previewHost.getBoundingClientRect()
+        const textareaRect = previewTextarea.getBoundingClientRect()
+        favoritesOverlayViewportStyles.value[panelName] = {
+            top: `${textareaRect.top - hostRect.top}px`,
+            left: `${textareaRect.left - hostRect.left}px`,
+            width: `${textareaRect.width}px`,
+            height: `${textareaRect.height}px`
+        }
+    }
+
+    favoritesOverlayStyles.value[panelName] = {
+        fontSize: style.fontSize,
+        lineHeight: style.lineHeight,
+        fontFamily: style.fontFamily,
+        letterSpacing: style.letterSpacing,
+        paddingTop: style.paddingTop,
+        paddingRight: `calc(${style.paddingRight} + ${suffixWidth}px)`,
+        paddingBottom: `calc(${style.paddingBottom} + ${suffixHeight}px)`,
+        paddingLeft: style.paddingLeft,
+        boxSizing: 'border-box'
+    }
+}
+
+const syncMainToPreview = (event: Event, panelName: number) => {
+    const target = event.target as HTMLTextAreaElement | null
+    const preview = favoritesPreviewTextareas.get(panelName)
+
+    if (!target || !preview || favoritesSyncing.has(panelName)) return
+
+    favoritesSyncing.add(panelName)
+    preview.scrollTop = target.scrollTop
+    setOverlayTransform(panelName, target.scrollTop)
+    requestAnimationFrame(() => {
+        favoritesSyncing.delete(panelName)
+    })
+}
+
+const syncPreviewToMain = (event: Event, panelName: number) => {
+    const target = event.target as HTMLTextAreaElement | null
+    const main = favoritesMainTextareas.get(panelName)
+
+    if (!target || !main || favoritesSyncing.has(panelName)) return
+
+    favoritesSyncing.add(panelName)
+    main.scrollTop = target.scrollTop
+    setOverlayTransform(panelName, target.scrollTop)
+    requestAnimationFrame(() => {
+        favoritesSyncing.delete(panelName)
+    })
+}
+
+const bindPanelScroll = (panelName: number) => {
+    const main = favoritesMainInputRefs.value[panelName]?.textareaElRef ?? null
+    const preview = favoritesPreviewInputRefs.value[panelName]?.textareaElRef ?? null
+
+    const currentMain = favoritesMainTextareas.get(panelName) ?? null
+    if (main !== currentMain) {
+        const oldMainListener = favoritesMainListeners.get(panelName)
+        if (currentMain && oldMainListener) {
+            currentMain.removeEventListener('scroll', oldMainListener)
+        }
+        favoritesMainTextareas.delete(panelName)
+        favoritesMainListeners.delete(panelName)
+
+        if (main) {
+            const listener = (event: Event) => syncMainToPreview(event, panelName)
+            main.addEventListener('scroll', listener, { passive: true })
+            favoritesMainTextareas.set(panelName, main)
+            favoritesMainListeners.set(panelName, listener)
+        }
+    }
+
+    const currentPreview = favoritesPreviewTextareas.get(panelName) ?? null
+    if (preview !== currentPreview) {
+        const oldPreviewListener = favoritesPreviewListeners.get(panelName)
+        if (currentPreview && oldPreviewListener) {
+            currentPreview.removeEventListener('scroll', oldPreviewListener)
+        }
+        favoritesPreviewTextareas.delete(panelName)
+        favoritesPreviewListeners.delete(panelName)
+
+        if (preview) {
+            preview.readOnly = true
+            const listener = (event: Event) => syncPreviewToMain(event, panelName)
+            preview.addEventListener('scroll', listener, { passive: true })
+            favoritesPreviewTextareas.set(panelName, preview)
+            favoritesPreviewListeners.set(panelName, listener)
+        }
+    }
+
+    updateOverlayStyle(panelName)
+    const currentScrollTop = main?.scrollTop ?? 0
+    if (preview) {
+        preview.scrollTop = currentScrollTop
+    }
+    setOverlayTransform(panelName, currentScrollTop)
+}
+
+const setMainInputRef = (panelName: number, inst: InputInst | null) => {
+    favoritesMainInputRefs.value[panelName] = inst
+    bindPanelScroll(panelName)
+}
+
+const setPreviewInputRef = (panelName: number, inst: InputInst | null) => {
+    favoritesPreviewInputRefs.value[panelName] = inst
+    bindPanelScroll(panelName)
+}
+
+onMounted(() => {
+    nextTick(() => {
+        moduleStore.moduleConfig.Favorites.favoritesTabPanels.forEach((panel) => {
+            bindPanelScroll(panel.name)
+        })
+    })
+})
+
+onUpdated(() => {
+    moduleStore.moduleConfig.Favorites.favoritesTabPanels.forEach((panel) => {
+        bindPanelScroll(panel.name)
+    })
+})
+
+onBeforeUnmount(() => {
+    favoritesMainTextareas.forEach((textarea, panelName) => {
+        const listener = favoritesMainListeners.get(panelName)
+        if (listener) {
+            textarea.removeEventListener('scroll', listener)
+        }
+    })
+
+    favoritesPreviewTextareas.forEach((textarea, panelName) => {
+        const listener = favoritesPreviewListeners.get(panelName)
+        if (listener) {
+            textarea.removeEventListener('scroll', listener)
+        }
+    })
+})
+
 const handleTabsValueUpdate = (value: number) => {
     moduleStore.moduleConfig.Favorites.favoritesTabsValue = value
 }
+
 const closeDisable = computed(() => {
     return moduleStore.moduleConfig.Favorites.favoritesTabPanels.length > 1
 })
+
 const handleTabsAdd = () => {
     if (moduleStore.moduleConfig.Favorites.enable) {
         message.error('停车后才能添加')
@@ -64,6 +249,7 @@ const handleTabsAdd = () => {
         moduleStore.moduleConfig.Favorites.favoritesTabsValue = newName
     }
 }
+
 const handleTabsClose = (name: number) => {
     if (moduleStore.moduleConfig.Favorites.enable) {
         message.error('停车后才能删除')
@@ -114,9 +300,11 @@ const handleStartSpamer = () => {
         })
     }
 }
+
 const handleStopSpamer = () => {
     favStop.stop('favorites')
 }
+
 const handleSendToText = () => {
     const currentTabValue = moduleStore.moduleConfig.Favorites.favoritesTabsValue
     const currentPanel = moduleStore.moduleConfig.Favorites.favoritesTabPanels.find(
@@ -251,15 +439,59 @@ const toggleSequentialMode = () => {
                         show-require-mark
                         :validation-status="panels.msg === '' ? 'error' : undefined"
                     >
-                        <n-input
-                            v-model:value="panels.msg"
-                            :disabled="isSendingPanel(panels.name)"
-                            round
-                            clearable
-                            show-count
-                            type="textarea"
-                            placeholder="默认每次弹幕发送字数为你文字独轮车设置的间隔，超出相应值将自动分割到下一条弹幕"
-                        />
+                        <div style="width: 100%">
+                            <n-input
+                                :ref="(inst) => setMainInputRef(panels.name, inst as InputInst | null)"
+                                v-model:value="panels.msg"
+                                :disabled="isSendingPanel(panels.name)"
+                                round
+                                clearable
+                                show-count
+                                type="textarea"
+                                placeholder="默认每次弹幕发送字数为你文字独轮车设置的间隔，超出相应值将自动分割到下一条弹幕"
+                            />
+
+                            <div v-if="!moduleStore.moduleConfig.Favorites.storytellerMode" class="preview-wrap">
+                                <div class="preview-title">
+                                    超长灰显预览（超过数量间隔的部分会被丢弃）
+                                </div>
+                                <div class="preview-overlay-wrap">
+                                    <n-input
+                                        :ref="(inst) => setPreviewInputRef(panels.name, inst as InputInst | null)"
+                                        round
+                                        type="textarea"
+                                        readonly
+                                        :show-count="true"
+                                        :value="panels.msg"
+                                        class="preview-base"
+                                    />
+                                    <div
+                                        class="preview-overlay-viewport"
+                                        :style="favoritesOverlayViewportStyles[panels.name] || {}"
+                                        aria-hidden="true"
+                                    >
+                                        <div
+                                            class="preview-overlay"
+                                            :style="{
+                                                ...(favoritesOverlayStyles[panels.name] || {}),
+                                                transform:
+                                                    favoritesOverlayTransforms[panels.name] ||
+                                                    'translateY(0px)'
+                                            }"
+                                        >
+                                            <div
+                                                class="preview-line"
+                                                v-for="(line, idx) in getPreviewLines(panels.msg)"
+                                                :key="`${panels.name}-${idx}`"
+                                            >
+                                                <span>{{ line.keep }}</span
+                                                ><span class="overflow">{{ line.overflow }}</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </n-form-item>
                 </n-tab-pane>
             </n-tabs>
@@ -283,3 +515,56 @@ const toggleSequentialMode = () => {
         </n-flex>
     </n-form>
 </template>
+
+<style scoped>
+.preview-wrap {
+    margin-top: 8px;
+}
+
+.preview-title {
+    margin-bottom: 4px;
+    font-size: 12px;
+    color: #909399;
+}
+
+.preview-overlay-wrap {
+    position: relative;
+    width: 100%;
+}
+
+.preview-base {
+    width: 100%;
+}
+
+.preview-base :deep(textarea) {
+    color: transparent;
+    caret-color: transparent;
+    overflow-x: hidden;
+}
+
+.preview-base :deep(.n-input__suffix) {
+    visibility: hidden;
+}
+
+.preview-overlay-viewport {
+    position: absolute;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.preview-overlay {
+    position: relative;
+    width: 100%;
+    min-height: 100%;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.preview-line {
+    min-height: 1.6em;
+}
+
+.overflow {
+    color: #b5b5b5;
+}
+</style>

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -669,7 +669,9 @@ const toggleSequentialMode = () => {
                                     class="preview-wrap"
                                 >
                                     <div class="preview-title">
-                                        逐行发送模式预览 - 橙色文字代表超过本行字数上限会被自动舍弃
+                                        预览：逐行发送文本 - 出现
+                                        <span class="preview-highlight-warning">橙色文字</span>
+                                        表示该文字超出每行字数上限，会被自动舍弃。必要时请考虑换行
                                     </div>
                                     <div class="preview-overlay-wrap">
                                         <n-input
@@ -776,6 +778,10 @@ const toggleSequentialMode = () => {
     margin-bottom: 4px;
     font-size: 12px;
     color: #909399;
+}
+
+.preview-highlight-warning {
+    color: #f47a4d;
 }
 
 .preview-overlay-wrap {

--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -81,25 +81,28 @@ const handleTabsClose = (name: number) => {
     }
 }
 const handleStartSpamer = () => {
-    const panelsWithEmptyMsg = _.filter(
-        moduleStore.moduleConfig.Favorites.favoritesTabPanels,
-        (panels) => _.isEmpty(panels.msg)
+    const currentPanel = moduleStore.moduleConfig.Favorites.favoritesTabPanels.find(
+        (panel) => panel.name === moduleStore.moduleConfig.Favorites.favoritesTabsValue
     )
 
-    if (!_.isEmpty(panelsWithEmptyMsg)) {
-        _.forEach(panelsWithEmptyMsg, (panels) => {
-            message.error(`${panels.tab}还没填内容呢`)
-        })
+    if (!currentPanel) {
+        message.error('未找到当前标签页')
+        return
+    }
+
+    if (_.isEmpty(currentPanel.msg)) {
+        message.error(`${currentPanel.tab || '当前标签页'}还没填内容呢`)
+        return
+    }
+
+    if (moduleStore.moduleConfig.Favorites.timeinterval === null) {
+        message.error('没参数你车什么?')
     } else {
-        if (moduleStore.moduleConfig.Favorites.timeinterval === null) {
-            message.error('没参数你车什么?')
-        } else {
-            uiStore.uiConfig.isShowPanel = false
-            moduleStore.moduleConfig.Favorites.enable = true
-            moduleStore.emitter.emit('Favorites', {
-                module: 'Favorites'
-            })
-        }
+        uiStore.uiConfig.isShowPanel = false
+        moduleStore.moduleConfig.Favorites.enable = true
+        moduleStore.emitter.emit('Favorites', {
+            module: 'Favorites'
+        })
     }
 }
 const handleStopSpamer = () => {
@@ -268,3 +271,4 @@ const toggleSequentialMode = () => {
         </n-flex>
     </n-form>
 </template>
+

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -510,7 +510,7 @@ const rules = {
 
                     <div v-if="!moduleStore.moduleConfig.TextSpam.storytellerMode" class="preview-wrap">
                         <div class="preview-title">
-                            逐行发送模式预览 - 灰色文字代表超过本行字数上限会被自动舍弃
+                            逐行发送模式预览 - 橙色文字代表超过本行字数上限会被自动舍弃
                         </div>
                         <div class="preview-overlay-wrap">
                             <n-input
@@ -646,7 +646,7 @@ const rules = {
 }
 
 .overflow {
-    color: #b5b5b5;
+    color: #f47a4d;
 }
 
 .emoji-trigger {

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -296,6 +296,13 @@ watch(
 )
 
 watch(
+    () => moduleStore.moduleConfig.TextSpam.storytellerMode,
+    () => {
+        scheduleTextRelayout()
+    }
+)
+
+watch(
     () => uiStore.uiConfig.activeMenuIndex,
     (menu) => {
         if (menu === 'TextView' && uiStore.uiConfig.isShowPanel) {

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -31,12 +31,14 @@ const textPreviewInputRef = ref<InputInst | null>(null)
 
 const textTextareaEl = ref<HTMLTextAreaElement | null>(null)
 const textPreviewTextareaEl = ref<HTMLTextAreaElement | null>(null)
+const textSelectionRange = ref<{ start: number; end: number } | null>(null)
 
 const textOverlayStyle = ref<Record<string, string>>({})
 const textOverlayViewportStyle = ref<Record<string, string>>({})
 const textOverlayTransform = ref('translateY(0px)')
 
 let textScrollListener: ((event: Event) => void) | null = null
+let textCursorListener: ((event: Event) => void) | null = null
 let textPreviewScrollListener: ((event: Event) => void) | null = null
 let textSyncing = false
 let textRelayoutTimer: ReturnType<typeof setTimeout> | null = null
@@ -141,6 +143,53 @@ const syncPreviewToMain = (event: Event) => {
     })
 }
 
+const updateTextSelectionRange = (event?: Event) => {
+    const target = (event?.target as HTMLTextAreaElement | null) ?? textTextareaEl.value
+    if (!target) return
+
+    const maxLength = target.value.length
+    const rawStart = target.selectionStart ?? maxLength
+    const rawEnd = target.selectionEnd ?? rawStart
+    const start = Math.max(0, Math.min(rawStart, maxLength))
+    const end = Math.max(start, Math.min(rawEnd, maxLength))
+    textSelectionRange.value = { start, end }
+}
+
+const insertEmojiToText = (emoji: string) => {
+    const text = moduleStore.moduleConfig.TextSpam.msg || ''
+    const activeTextarea = textTextareaEl.value
+    const preserveScrollTop = activeTextarea?.scrollTop ?? 0
+    const preserveScrollLeft = activeTextarea?.scrollLeft ?? 0
+    const activeRange =
+        activeTextarea && document.activeElement === activeTextarea
+            ? {
+                  start: activeTextarea.selectionStart ?? text.length,
+                  end: activeTextarea.selectionEnd ?? text.length
+              }
+            : null
+    const range = activeRange ?? textSelectionRange.value ?? { start: text.length, end: text.length }
+    const start = Math.max(0, Math.min(range.start, text.length))
+    const end = Math.max(start, Math.min(range.end, text.length))
+
+    moduleStore.moduleConfig.TextSpam.msg = `${text.slice(0, start)}${emoji}${text.slice(end)}`
+    const cursor = start + emoji.length
+    textSelectionRange.value = { start: cursor, end: cursor }
+
+    nextTick(() => {
+        const textarea = textTextareaEl.value
+        if (!textarea) return
+        const restoreCursor = () => {
+            textarea.focus()
+            textarea.setSelectionRange(cursor, cursor)
+            textarea.scrollTop = preserveScrollTop
+            textarea.scrollLeft = preserveScrollLeft
+            updateTextSelectionRange()
+        }
+        restoreCursor()
+        requestAnimationFrame(() => restoreCursor())
+    })
+}
+
 const bindTextScroll = () => {
     const main = textInputRef.value?.textareaElRef ?? null
     const preview = textPreviewInputRef.value?.textareaElRef ?? null
@@ -149,12 +198,25 @@ const bindTextScroll = () => {
         if (textTextareaEl.value && textScrollListener) {
             textTextareaEl.value.removeEventListener('scroll', textScrollListener)
         }
+        if (textTextareaEl.value && textCursorListener) {
+            textTextareaEl.value.removeEventListener('click', textCursorListener)
+            textTextareaEl.value.removeEventListener('keyup', textCursorListener)
+            textTextareaEl.value.removeEventListener('select', textCursorListener)
+            textTextareaEl.value.removeEventListener('input', textCursorListener)
+        }
         textTextareaEl.value = main
         if (main) {
             textScrollListener = (event: Event) => syncMainToPreview(event)
             main.addEventListener('scroll', textScrollListener, { passive: true })
+            textCursorListener = (event: Event) => updateTextSelectionRange(event)
+            main.addEventListener('click', textCursorListener, { passive: true })
+            main.addEventListener('keyup', textCursorListener, { passive: true })
+            main.addEventListener('select', textCursorListener, { passive: true })
+            main.addEventListener('input', textCursorListener, { passive: true })
+            updateTextSelectionRange()
         } else {
             textScrollListener = null
+            textCursorListener = null
         }
     }
 
@@ -225,6 +287,12 @@ watch(
 onBeforeUnmount(() => {
     if (textTextareaEl.value && textScrollListener) {
         textTextareaEl.value.removeEventListener('scroll', textScrollListener)
+    }
+    if (textTextareaEl.value && textCursorListener) {
+        textTextareaEl.value.removeEventListener('click', textCursorListener)
+        textTextareaEl.value.removeEventListener('keyup', textCursorListener)
+        textTextareaEl.value.removeEventListener('select', textCursorListener)
+        textTextareaEl.value.removeEventListener('input', textCursorListener)
     }
     if (textPreviewTextareaEl.value && textPreviewScrollListener) {
         textPreviewTextareaEl.value.removeEventListener('scroll', textPreviewScrollListener)
@@ -483,7 +551,7 @@ const rules = {
                                 :src="data.url"
                                 object-fit="contain"
                                 style="cursor: pointer"
-                                @click="moduleStore.moduleConfig.TextSpam.msg += data.emoji"
+                                @click="insertEmojiToText(data.emoji)"
                             />
                         </div>
                     </div>

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -308,7 +308,7 @@ const rules = {
 <template>
     <n-form :rules="rules" :disabled="moduleStore.moduleConfig.TextSpam.enable">
         <n-page-header subtitle="文字独轮车" style="margin-bottom: 10px" />
-        <n-form-item :show-label="false">
+        <n-form-item :show-label="false" :show-feedback="false">
             <n-flex align="center">
                 <n-form-item label="时间间隔" path="timeinterval">
                     <n-popover trigger="hover" style="max-width: 300px" placement="bottom">
@@ -404,90 +404,91 @@ const rules = {
                 >
                     按顺序发送 {{ moduleStore.moduleConfig.TextSpam.sequentialMode ? '开' : '关' }}
                 </button>
-                <span style="font-size: 12px; color: #909399"
-                    >提示：运行中修改开关不会立即生效，下次点击“开车”生效</span
-                >
             </n-flex>
         </n-form-item>
 
         <n-form-item label="发送内容" path="msg">
-            <div style="width: 100%">
-                <n-input
-                    ref="textInputRef"
-                    round
-                    clearable
-                    type="textarea"
-                    show-count
-                    v-model:value="moduleStore.moduleConfig.TextSpam.msg"
-                    placeholder="车了可能会被禁，但不车就等于一直被禁"
-                />
+            <n-flex align="flex-start" :wrap="false" style="width: 100%; gap: 8px">
+                <div style="width: 100%">
+                    <n-input
+                        ref="textInputRef"
+                        round
+                        clearable
+                        type="textarea"
+                        show-count
+                        v-model:value="moduleStore.moduleConfig.TextSpam.msg"
+                        placeholder="车了可能会被禁，但不车就等于一直被禁"
+                    />
 
-                <div v-if="!moduleStore.moduleConfig.TextSpam.storytellerMode" class="preview-wrap">
-                    <div class="preview-title">超长灰显预览（超过数量间隔的部分会被丢弃）</div>
-                    <div class="preview-overlay-wrap">
-                        <n-input
-                            ref="textPreviewInputRef"
-                            round
-                            type="textarea"
-                            readonly
-                            :show-count="true"
-                            :value="moduleStore.moduleConfig.TextSpam.msg"
-                            class="preview-base"
-                        />
-                        <div
-                            class="preview-overlay-viewport"
-                            :style="textOverlayViewportStyle"
-                            aria-hidden="true"
-                        >
+                    <div v-if="!moduleStore.moduleConfig.TextSpam.storytellerMode" class="preview-wrap">
+                        <div class="preview-title">
+                            逐行发送模式预览 - 灰色文字代表超过本行字数上限会被自动舍弃
+                        </div>
+                        <div class="preview-overlay-wrap">
+                            <n-input
+                                ref="textPreviewInputRef"
+                                round
+                                type="textarea"
+                                readonly
+                                :show-count="true"
+                                :value="moduleStore.moduleConfig.TextSpam.msg"
+                                class="preview-base"
+                            />
                             <div
-                                class="preview-overlay"
-                                :style="{
-                                    ...textOverlayStyle,
-                                    transform: textOverlayTransform
-                                }"
+                                class="preview-overlay-viewport"
+                                :style="textOverlayViewportStyle"
+                                aria-hidden="true"
                             >
-                                <div class="preview-line" v-for="(line, idx) in textPreviewLines" :key="idx">
-                                    <span>{{ line.keep }}</span><span class="overflow">{{ line.overflow }}</span>
+                                <div
+                                    class="preview-overlay"
+                                    :style="{
+                                        ...textOverlayStyle,
+                                        transform: textOverlayTransform
+                                    }"
+                                >
+                                    <div class="preview-line" v-for="(line, idx) in textPreviewLines" :key="idx">
+                                        <span>{{ line.keep }}</span><span class="overflow">{{ line.overflow }}</span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
 
-            <n-popover trigger="click" placement="left" style="width: 500px">
-                <template #trigger>
-                    <n-button text style="padding-left: 4px">
-                        <n-icon :size="24">
-                            <EmotionIcon />
-                        </n-icon>
-                    </n-button>
-                </template>
-                <div
-                    style="
-                        display: grid;
-                        grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
-                        gap: 8px;
-                        padding: 8px;
-                    "
-                >
+                <n-popover trigger="click" placement="left" style="width: 500px">
+                    <template #trigger>
+                        <n-button text class="emoji-trigger">
+                            <n-icon :size="24">
+                                <EmotionIcon />
+                            </n-icon>
+                        </n-button>
+                    </template>
                     <div
-                        v-for="data in biliStore.emotionData.find((data) => data.pkg_id === 100)
-                            ?.emoticons"
-                        :key="data.emoticon_id"
-                        :disabled="data.perm === 0"
+                        style="
+                            display: grid;
+                            grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+                            gap: 8px;
+                            padding: 8px;
+                        "
                     >
-                        <n-avatar
-                            :color="uiStore.uiConfig.theme === 'dark' ? '#48484E' : 'white'"
-                            :size="24"
-                            :src="data.url"
-                            object-fit="contain"
-                            style="cursor: pointer"
-                            @click="moduleStore.moduleConfig.TextSpam.msg += data.emoji"
-                        />
+                        <div
+                            v-for="data in biliStore.emotionData.find((data) => data.pkg_id === 100)
+                                ?.emoticons"
+                            :key="data.emoticon_id"
+                            :disabled="data.perm === 0"
+                        >
+                            <n-avatar
+                                :color="uiStore.uiConfig.theme === 'dark' ? '#48484E' : 'white'"
+                                :size="24"
+                                :src="data.url"
+                                object-fit="contain"
+                                style="cursor: pointer"
+                                @click="moduleStore.moduleConfig.TextSpam.msg += data.emoji"
+                            />
+                        </div>
                     </div>
-                </div>
-            </n-popover>
+                </n-popover>
+            </n-flex>
         </n-form-item>
         <n-flex
             justify="end"
@@ -558,5 +559,10 @@ const rules = {
 
 .overflow {
     color: #b5b5b5;
+}
+
+.emoji-trigger {
+    padding-left: 4px;
+    margin-top: 2px;
 }
 </style>

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -48,6 +48,16 @@ const handleStopSpamer = () => {
     tStop.stop('text')
 }
 
+const toggleStorytellerMode = () => {
+    moduleStore.moduleConfig.TextSpam.storytellerMode =
+        !moduleStore.moduleConfig.TextSpam.storytellerMode
+}
+
+const toggleSequentialMode = () => {
+    moduleStore.moduleConfig.TextSpam.sequentialMode =
+        !moduleStore.moduleConfig.TextSpam.sequentialMode
+}
+
 const rules = {
     timeinterval: {
         required: true,
@@ -146,6 +156,49 @@ const rules = {
                 </n-form-item>
             </n-flex>
         </n-form-item>
+
+        <n-form-item :show-label="false">
+            <n-flex align="center" style="gap: 8px; width: 100%">
+                <button
+                    type="button"
+                    :disabled="moduleStore.moduleConfig.TextSpam.enable"
+                    @click="toggleStorytellerMode"
+                    :style="{
+                        padding: '4px 10px',
+                        borderRadius: '999px',
+                        border: '1px solid #bfbfbf',
+                        cursor: moduleStore.moduleConfig.TextSpam.enable ? 'not-allowed' : 'pointer',
+                        color: moduleStore.moduleConfig.TextSpam.storytellerMode ? '#fff' : '#333',
+                        backgroundColor: moduleStore.moduleConfig.TextSpam.storytellerMode
+                            ? '#18a058'
+                            : '#fff'
+                    }"
+                >
+                    说书模式 {{ moduleStore.moduleConfig.TextSpam.storytellerMode ? '开' : '关' }}
+                </button>
+                <button
+                    type="button"
+                    :disabled="moduleStore.moduleConfig.TextSpam.enable"
+                    @click="toggleSequentialMode"
+                    :style="{
+                        padding: '4px 10px',
+                        borderRadius: '999px',
+                        border: '1px solid #bfbfbf',
+                        cursor: moduleStore.moduleConfig.TextSpam.enable ? 'not-allowed' : 'pointer',
+                        color: moduleStore.moduleConfig.TextSpam.sequentialMode ? '#fff' : '#333',
+                        backgroundColor: moduleStore.moduleConfig.TextSpam.sequentialMode
+                            ? '#18a058'
+                            : '#fff'
+                    }"
+                >
+                    按顺序发送 {{ moduleStore.moduleConfig.TextSpam.sequentialMode ? '开' : '关' }}
+                </button>
+                <span style="font-size: 12px; color: #909399"
+                    >提示：运行中修改开关不会立即生效，下次点击“开车”生效</span
+                >
+            </n-flex>
+        </n-form-item>
+
         <n-form-item label="发送内容" path="msg">
             <n-input
                 round
@@ -207,5 +260,3 @@ const rules = {
         </n-flex>
     </n-form>
 </template>
-
-

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, nextTick, onMounted, onUpdated, onBeforeUnmount } from 'vue'
+import { computed, ref, nextTick, onMounted, onUpdated, onBeforeUnmount, watch } from 'vue'
 import {
     NButton,
     NForm,
@@ -39,6 +39,7 @@ const textOverlayTransform = ref('translateY(0px)')
 let textScrollListener: ((event: Event) => void) | null = null
 let textPreviewScrollListener: ((event: Event) => void) | null = null
 let textSyncing = false
+let textRelayoutTimer: ReturnType<typeof setTimeout> | null = null
 
 const textinterval = computed(() => Math.max(1, Number(moduleStore.moduleConfig.TextSpam.textinterval || 1)))
 
@@ -51,6 +52,29 @@ const textPreviewLines = computed(() => {
 
 const setTextOverlayTransform = (scrollTop: number) => {
     textOverlayTransform.value = `translateY(${-scrollTop}px)`
+}
+
+const getOffsetToAncestor = (el: HTMLElement, ancestor: HTMLElement) => {
+    let top = 0
+    let left = 0
+    let current: HTMLElement | null = el
+
+    while (current && current !== ancestor) {
+        top += current.offsetTop
+        left += current.offsetLeft
+        current = current.offsetParent as HTMLElement | null
+    }
+
+    if (current !== ancestor) {
+        const hostRect = ancestor.getBoundingClientRect()
+        const elRect = el.getBoundingClientRect()
+        return {
+            top: elRect.top - hostRect.top,
+            left: elRect.left - hostRect.left
+        }
+    }
+
+    return { top, left }
 }
 
 const updateTextOverlayStyle = () => {
@@ -67,15 +91,17 @@ const updateTextOverlayStyle = () => {
     const suffixHeight = suffix?.offsetHeight ?? 0
 
     const previewHost = previewWrapper.closest('.preview-overlay-wrap') as HTMLElement | null
-    if (previewHost) {
-        const hostRect = previewHost.getBoundingClientRect()
-        const textareaRect = previewTextarea.getBoundingClientRect()
-        textOverlayViewportStyle.value = {
-            top: `${textareaRect.top - hostRect.top}px`,
-            left: `${textareaRect.left - hostRect.left}px`,
-            width: `${textareaRect.width}px`,
-            height: `${textareaRect.height}px`
-        }
+    if (!previewHost) return
+    const { top, left } = getOffsetToAncestor(previewTextarea, previewHost)
+    const width = previewTextarea.offsetWidth
+    const height = previewTextarea.offsetHeight
+    if (width <= 1 || height <= 1) return
+
+    textOverlayViewportStyle.value = {
+        top: `${top}px`,
+        left: `${left}px`,
+        width: `${width}px`,
+        height: `${height}px`
     }
 
     textOverlayStyle.value = {
@@ -154,13 +180,47 @@ const bindTextScroll = () => {
     setTextOverlayTransform(currentScrollTop)
 }
 
+const scheduleTextRelayout = () => {
+    if (textRelayoutTimer) {
+        clearTimeout(textRelayoutTimer)
+        textRelayoutTimer = null
+    }
+
+    nextTick(() => {
+        bindTextScroll()
+        requestAnimationFrame(() => bindTextScroll())
+        textRelayoutTimer = setTimeout(() => {
+            bindTextScroll()
+            textRelayoutTimer = null
+        }, 360)
+    })
+}
+
 onMounted(() => {
-    nextTick(() => bindTextScroll())
+    scheduleTextRelayout()
 })
 
 onUpdated(() => {
     bindTextScroll()
 })
+
+watch(
+    () => uiStore.uiConfig.isShowPanel,
+    (show) => {
+        if (show && uiStore.uiConfig.activeMenuIndex === 'TextView') {
+            scheduleTextRelayout()
+        }
+    }
+)
+
+watch(
+    () => uiStore.uiConfig.activeMenuIndex,
+    (menu) => {
+        if (menu === 'TextView' && uiStore.uiConfig.isShowPanel) {
+            scheduleTextRelayout()
+        }
+    }
+)
 
 onBeforeUnmount(() => {
     if (textTextareaEl.value && textScrollListener) {
@@ -168,6 +228,10 @@ onBeforeUnmount(() => {
     }
     if (textPreviewTextareaEl.value && textPreviewScrollListener) {
         textPreviewTextareaEl.value.removeEventListener('scroll', textPreviewScrollListener)
+    }
+    if (textRelayoutTimer) {
+        clearTimeout(textRelayoutTimer)
+        textRelayoutTimer = null
     }
 })
 

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -308,7 +308,7 @@ const rules = {
 <template>
     <n-form :rules="rules" :disabled="moduleStore.moduleConfig.TextSpam.enable">
         <n-page-header subtitle="文字独轮车" style="margin-bottom: 10px" />
-        <n-form-item :show-label="false" :show-feedback="false">
+        <n-form-item :show-label="false">
             <n-flex align="center">
                 <n-form-item label="时间间隔" path="timeinterval">
                     <n-popover trigger="hover" style="max-width: 300px" placement="bottom">
@@ -368,7 +368,7 @@ const rules = {
             </n-flex>
         </n-form-item>
 
-        <n-form-item :show-label="false">
+        <n-form-item label="模式选择">
             <n-flex align="center" style="gap: 8px; width: 100%">
                 <button
                     type="button"

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -59,7 +59,7 @@ const rules = {
     },
     textinterval: {
         required: true,
-        message: `输入一个大于0，小于的${biliStore.infoByuser?.property.danmu.length}的数字`,
+        message: `输入一个大于0，小于的${biliStore.danmuLengthLimit}的数字`,
         trigger: ['input', 'blur'],
         validator: () => {
             return moduleStore.moduleConfig.TextSpam.textinterval !== null
@@ -115,15 +115,15 @@ const rules = {
                                 clearable
                                 :show-button="false"
                                 v-model:value="moduleStore.moduleConfig.TextSpam.textinterval"
-                                placeholder="默认20"
+                                placeholder="默认当前账号上限"
                                 min="1"
-                                :max="biliStore.infoByuser?.property.danmu.length"
+                                :max="biliStore.danmuLengthLimit ?? undefined"
                                 :precision="0"
                             />
                         </template>
                         <span
                             >每次弹幕发送字数, 最大为
-                            {{ biliStore.infoByuser?.property.danmu.length }}
+                            {{ biliStore.danmuLengthLimit }}
                         </span>
                     </n-popover>
                 </n-form-item>
@@ -207,3 +207,5 @@ const rules = {
         </n-flex>
     </n-form>
 </template>
+
+

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -517,7 +517,9 @@ const rules = {
 
                     <div v-if="!moduleStore.moduleConfig.TextSpam.storytellerMode" class="preview-wrap">
                         <div class="preview-title">
-                            逐行发送模式预览 - 橙色文字代表超过本行字数上限会被自动舍弃
+                            预览：逐行发送文本 - 出现
+                            <span class="preview-highlight-warning">橙色文字</span>
+                            表示该文字超出每行字数上限，会被自动舍弃。必要时请考虑换行
                         </div>
                         <div class="preview-overlay-wrap">
                             <n-input
@@ -613,6 +615,10 @@ const rules = {
     margin-bottom: 4px;
     font-size: 12px;
     color: #909399;
+}
+
+.preview-highlight-warning {
+    color: #f47a4d;
 }
 
 .preview-overlay-wrap {

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -53,7 +53,9 @@ const textPreviewLines = computed(() => {
 })
 
 const setTextOverlayTransform = (scrollTop: number) => {
-    textOverlayTransform.value = `translateY(${-scrollTop}px)`
+    const transform = `translateY(${-scrollTop}px)`
+    if (textOverlayTransform.value === transform) return
+    textOverlayTransform.value = transform
 }
 
 const getOffsetToAncestor = (el: HTMLElement, ancestor: HTMLElement) => {
@@ -79,6 +81,24 @@ const getOffsetToAncestor = (el: HTMLElement, ancestor: HTMLElement) => {
     return { top, left }
 }
 
+const isSameStyleRecord = (
+    current: Record<string, string>,
+    next: Record<string, string>
+) => {
+    const currentKeys = Object.keys(current)
+    const nextKeys = Object.keys(next)
+    if (currentKeys.length !== nextKeys.length) return false
+    return nextKeys.every((key) => current[key] === next[key])
+}
+
+const setStyleIfChanged = (
+    styleRef: { value: Record<string, string> },
+    nextStyle: Record<string, string>
+) => {
+    if (isSameStyleRecord(styleRef.value, nextStyle)) return
+    styleRef.value = nextStyle
+}
+
 const updateTextOverlayStyle = () => {
     const textarea = textInputRef.value?.textareaElRef
     const wrapper = textInputRef.value?.wrapperElRef
@@ -99,14 +119,14 @@ const updateTextOverlayStyle = () => {
     const height = previewTextarea.offsetHeight
     if (width <= 1 || height <= 1) return
 
-    textOverlayViewportStyle.value = {
+    setStyleIfChanged(textOverlayViewportStyle, {
         top: `${top}px`,
         left: `${left}px`,
         width: `${width}px`,
         height: `${height}px`
-    }
+    })
 
-    textOverlayStyle.value = {
+    setStyleIfChanged(textOverlayStyle, {
         fontSize: style.fontSize,
         lineHeight: style.lineHeight,
         fontFamily: style.fontFamily,
@@ -116,7 +136,7 @@ const updateTextOverlayStyle = () => {
         paddingBottom: `calc(${style.paddingBottom} + ${suffixHeight}px)`,
         paddingLeft: style.paddingLeft,
         boxSizing: 'border-box'
-    }
+    })
 }
 
 const syncMainToPreview = (event: Event) => {

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, ref, nextTick, onMounted, onUpdated, onBeforeUnmount } from 'vue'
 import {
     NButton,
     NForm,
@@ -12,6 +13,7 @@ import {
     NIcon,
     NAvatar
 } from 'naive-ui'
+import type { InputInst } from 'naive-ui'
 import { useUIStore } from '@/stores/useUIStore'
 import { useModuleStore } from '@/stores/useModuleStore'
 import { useBiliStore } from '@/stores/useBiliStore'
@@ -23,6 +25,151 @@ const moduleStore = useModuleStore()
 const biliStore = useBiliStore()
 const message = useMessage()
 const tStop = new stop('StopTextSpamer')
+
+const textInputRef = ref<InputInst | null>(null)
+const textPreviewInputRef = ref<InputInst | null>(null)
+
+const textTextareaEl = ref<HTMLTextAreaElement | null>(null)
+const textPreviewTextareaEl = ref<HTMLTextAreaElement | null>(null)
+
+const textOverlayStyle = ref<Record<string, string>>({})
+const textOverlayViewportStyle = ref<Record<string, string>>({})
+const textOverlayTransform = ref('translateY(0px)')
+
+let textScrollListener: ((event: Event) => void) | null = null
+let textPreviewScrollListener: ((event: Event) => void) | null = null
+let textSyncing = false
+
+const textinterval = computed(() => Math.max(1, Number(moduleStore.moduleConfig.TextSpam.textinterval || 1)))
+
+const textPreviewLines = computed(() => {
+    return moduleStore.moduleConfig.TextSpam.msg.split(/\r?\n/).map((line) => ({
+        keep: line.slice(0, textinterval.value),
+        overflow: line.slice(textinterval.value)
+    }))
+})
+
+const setTextOverlayTransform = (scrollTop: number) => {
+    textOverlayTransform.value = `translateY(${-scrollTop}px)`
+}
+
+const updateTextOverlayStyle = () => {
+    const textarea = textInputRef.value?.textareaElRef
+    const wrapper = textInputRef.value?.wrapperElRef
+    const previewTextarea = textPreviewInputRef.value?.textareaElRef
+    const previewWrapper = textPreviewInputRef.value?.wrapperElRef
+
+    if (!textarea || !wrapper || !previewTextarea || !previewWrapper) return
+
+    const style = getComputedStyle(textarea)
+    const suffix = wrapper.querySelector('.n-input__suffix') as HTMLElement | null
+    const suffixWidth = suffix?.offsetWidth ?? 0
+    const suffixHeight = suffix?.offsetHeight ?? 0
+
+    const previewHost = previewWrapper.closest('.preview-overlay-wrap') as HTMLElement | null
+    if (previewHost) {
+        const hostRect = previewHost.getBoundingClientRect()
+        const textareaRect = previewTextarea.getBoundingClientRect()
+        textOverlayViewportStyle.value = {
+            top: `${textareaRect.top - hostRect.top}px`,
+            left: `${textareaRect.left - hostRect.left}px`,
+            width: `${textareaRect.width}px`,
+            height: `${textareaRect.height}px`
+        }
+    }
+
+    textOverlayStyle.value = {
+        fontSize: style.fontSize,
+        lineHeight: style.lineHeight,
+        fontFamily: style.fontFamily,
+        letterSpacing: style.letterSpacing,
+        paddingTop: style.paddingTop,
+        paddingRight: `calc(${style.paddingRight} + ${suffixWidth}px)`,
+        paddingBottom: `calc(${style.paddingBottom} + ${suffixHeight}px)`,
+        paddingLeft: style.paddingLeft,
+        boxSizing: 'border-box'
+    }
+}
+
+const syncMainToPreview = (event: Event) => {
+    const target = event.target as HTMLTextAreaElement | null
+    if (!target || !textPreviewTextareaEl.value || textSyncing) return
+
+    textSyncing = true
+    textPreviewTextareaEl.value.scrollTop = target.scrollTop
+    setTextOverlayTransform(target.scrollTop)
+    requestAnimationFrame(() => {
+        textSyncing = false
+    })
+}
+
+const syncPreviewToMain = (event: Event) => {
+    const target = event.target as HTMLTextAreaElement | null
+    if (!target || !textTextareaEl.value || textSyncing) return
+
+    textSyncing = true
+    textTextareaEl.value.scrollTop = target.scrollTop
+    setTextOverlayTransform(target.scrollTop)
+    requestAnimationFrame(() => {
+        textSyncing = false
+    })
+}
+
+const bindTextScroll = () => {
+    const main = textInputRef.value?.textareaElRef ?? null
+    const preview = textPreviewInputRef.value?.textareaElRef ?? null
+
+    if (main !== textTextareaEl.value) {
+        if (textTextareaEl.value && textScrollListener) {
+            textTextareaEl.value.removeEventListener('scroll', textScrollListener)
+        }
+        textTextareaEl.value = main
+        if (main) {
+            textScrollListener = (event: Event) => syncMainToPreview(event)
+            main.addEventListener('scroll', textScrollListener, { passive: true })
+        } else {
+            textScrollListener = null
+        }
+    }
+
+    if (preview !== textPreviewTextareaEl.value) {
+        if (textPreviewTextareaEl.value && textPreviewScrollListener) {
+            textPreviewTextareaEl.value.removeEventListener('scroll', textPreviewScrollListener)
+        }
+        textPreviewTextareaEl.value = preview
+        if (preview) {
+            preview.readOnly = true
+            textPreviewScrollListener = (event: Event) => syncPreviewToMain(event)
+            preview.addEventListener('scroll', textPreviewScrollListener, { passive: true })
+        } else {
+            textPreviewScrollListener = null
+        }
+    }
+
+    updateTextOverlayStyle()
+    const currentScrollTop = main?.scrollTop ?? 0
+    if (preview) {
+        preview.scrollTop = currentScrollTop
+    }
+    setTextOverlayTransform(currentScrollTop)
+}
+
+onMounted(() => {
+    nextTick(() => bindTextScroll())
+})
+
+onUpdated(() => {
+    bindTextScroll()
+})
+
+onBeforeUnmount(() => {
+    if (textTextareaEl.value && textScrollListener) {
+        textTextareaEl.value.removeEventListener('scroll', textScrollListener)
+    }
+    if (textPreviewTextareaEl.value && textPreviewScrollListener) {
+        textPreviewTextareaEl.value.removeEventListener('scroll', textPreviewScrollListener)
+    }
+})
 
 const handleStartSpamer = () => {
     if (
@@ -200,14 +347,50 @@ const rules = {
         </n-form-item>
 
         <n-form-item label="发送内容" path="msg">
-            <n-input
-                round
-                clearable
-                type="textarea"
-                show-count
-                v-model:value="moduleStore.moduleConfig.TextSpam.msg"
-                placeholder="车了可能会被禁，但不车就等于一直被禁"
-            />
+            <div style="width: 100%">
+                <n-input
+                    ref="textInputRef"
+                    round
+                    clearable
+                    type="textarea"
+                    show-count
+                    v-model:value="moduleStore.moduleConfig.TextSpam.msg"
+                    placeholder="车了可能会被禁，但不车就等于一直被禁"
+                />
+
+                <div v-if="!moduleStore.moduleConfig.TextSpam.storytellerMode" class="preview-wrap">
+                    <div class="preview-title">超长灰显预览（超过数量间隔的部分会被丢弃）</div>
+                    <div class="preview-overlay-wrap">
+                        <n-input
+                            ref="textPreviewInputRef"
+                            round
+                            type="textarea"
+                            readonly
+                            :show-count="true"
+                            :value="moduleStore.moduleConfig.TextSpam.msg"
+                            class="preview-base"
+                        />
+                        <div
+                            class="preview-overlay-viewport"
+                            :style="textOverlayViewportStyle"
+                            aria-hidden="true"
+                        >
+                            <div
+                                class="preview-overlay"
+                                :style="{
+                                    ...textOverlayStyle,
+                                    transform: textOverlayTransform
+                                }"
+                            >
+                                <div class="preview-line" v-for="(line, idx) in textPreviewLines" :key="idx">
+                                    <span>{{ line.keep }}</span><span class="overflow">{{ line.overflow }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <n-popover trigger="click" placement="left" style="width: 500px">
                 <template #trigger>
                     <n-button text style="padding-left: 4px">
@@ -260,3 +443,56 @@ const rules = {
         </n-flex>
     </n-form>
 </template>
+
+<style scoped>
+.preview-wrap {
+    margin-top: 8px;
+}
+
+.preview-title {
+    margin-bottom: 4px;
+    font-size: 12px;
+    color: #909399;
+}
+
+.preview-overlay-wrap {
+    position: relative;
+    width: 100%;
+}
+
+.preview-base {
+    width: 100%;
+}
+
+.preview-base :deep(textarea) {
+    color: transparent;
+    caret-color: transparent;
+    overflow-x: hidden;
+}
+
+.preview-base :deep(.n-input__suffix) {
+    visibility: hidden;
+}
+
+.preview-overlay-viewport {
+    position: absolute;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.preview-overlay {
+    position: relative;
+    width: 100%;
+    min-height: 100%;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.preview-line {
+    min-height: 1.6em;
+}
+
+.overflow {
+    color: #b5b5b5;
+}
+</style>

--- a/src/modules/Spamer/textSpamer.ts
+++ b/src/modules/Spamer/textSpamer.ts
@@ -17,6 +17,12 @@ interface TextRunOptions extends SpamConfig {
     sequentialMode: boolean
 }
 
+interface FavoritesRunOptions extends SpamConfig {
+    textinterval: number
+    storytellerMode: boolean
+    sequentialMode: boolean
+}
+
 class TextSpamer extends BaseModule {
     private textConfig = this.moduleStore.moduleConfig.TextSpam
     private favoritesConfig = this.moduleStore.moduleConfig.Favorites
@@ -25,10 +31,6 @@ class TextSpamer extends BaseModule {
 
     private get roomId(): number | undefined {
         return useBiliStore().BilibiliLive?.ROOMID
-    }
-
-    private formatMsg(msg: string): string {
-        return msg.replace(/\n/g, '')
     }
 
     private sliceMsg(msg: string, maxLength: number): string[] {
@@ -48,7 +50,7 @@ class TextSpamer extends BaseModule {
         return Math.min(minLimited, danmuLengthLimit)
     }
 
-    private formatTextMsgsByLine(msg: string, textinterval: number): string[] {
+    private formatMsgsByLine(msg: string, textinterval: number): string[] {
         return msg
             .split(/\r?\n/)
             .map((line) => line.trim())
@@ -57,16 +59,17 @@ class TextSpamer extends BaseModule {
             .filter((line) => line.length > 0)
     }
 
-    private formatTextMsgsByStory(msg: string, textinterval: number): string[] {
+    private formatMsgsByStory(msg: string, textinterval: number): string[] {
         const flattened = msg.replace(/\r?\n/g, '')
         return this.sliceMsg(flattened, textinterval).filter((line) => line.length > 0)
     }
 
-    private formatFavorites(): string[] {
+    private formatFavorites(options: FavoritesRunOptions): string[] {
         return _.flatMap(this.favoritesConfig.favoritesTabPanels, (item) => {
             if (!item.msg) return []
-            const processedMsg = this.formatMsg(item.msg)
-            return this.sliceMsg(processedMsg, this.textConfig.textinterval)
+            return options.storytellerMode
+                ? this.formatMsgsByStory(item.msg, options.textinterval)
+                : this.formatMsgsByLine(item.msg, options.textinterval)
         })
     }
 
@@ -167,8 +170,8 @@ class TextSpamer extends BaseModule {
         this.textConfig.textinterval = runOptions.textinterval
 
         const msgs = runOptions.storytellerMode
-            ? this.formatTextMsgsByStory(this.textConfig.msg, runOptions.textinterval)
-            : this.formatTextMsgsByLine(this.textConfig.msg, runOptions.textinterval)
+            ? this.formatMsgsByStory(this.textConfig.msg, runOptions.textinterval)
+            : this.formatMsgsByLine(this.textConfig.msg, runOptions.textinterval)
 
         if (msgs.length === 0) return
 
@@ -192,11 +195,24 @@ class TextSpamer extends BaseModule {
         this.cleanUP()
         if (!this.roomId) return
 
-        const msgs = this.formatFavorites()
+        const runOptions: FavoritesRunOptions = {
+            enable: this.favoritesConfig.enable,
+            timeinterval: this.favoritesConfig.timeinterval,
+            textinterval: this.clampTextInterval(this.textConfig.textinterval),
+            storytellerMode: this.favoritesConfig.storytellerMode,
+            sequentialMode: this.favoritesConfig.sequentialMode
+        }
+
+        const msgs = this.formatFavorites(runOptions)
         if (msgs.length === 0) return
 
-        const timeinterval = this.formatTime(this.favoritesConfig.timeinterval)
-        this.createCycleSender(msgs, this.roomId, timeinterval, this.favoritesConfig)
+        const timeinterval = this.formatTime(runOptions.timeinterval)
+
+        if (runOptions.sequentialMode) {
+            this.createCycleSender(msgs, this.roomId, timeinterval, this.favoritesConfig)
+        } else {
+            this.createRandomSender(msgs, this.roomId, timeinterval, this.favoritesConfig)
+        }
     }
 
     public stop(area: SpamArea): void {

--- a/src/modules/Spamer/textSpamer.ts
+++ b/src/modules/Spamer/textSpamer.ts
@@ -11,6 +11,12 @@ interface SpamConfig {
     timeinterval: number
 }
 
+interface TextRunOptions extends SpamConfig {
+    textinterval: number
+    storytellerMode: boolean
+    sequentialMode: boolean
+}
+
 class TextSpamer extends BaseModule {
     private textConfig = this.moduleStore.moduleConfig.TextSpam
     private favoritesConfig = this.moduleStore.moduleConfig.Favorites
@@ -30,13 +36,30 @@ class TextSpamer extends BaseModule {
         return msg.match(new RegExp(`.{1,${maxLength}}`, 'g')) || []
     }
 
-    private formatTextMsgsByLine(): string[] {
-        return this.textConfig.msg
+    private clampTextInterval(textinterval: number): number {
+        const raw = Number.isFinite(textinterval) ? Math.floor(textinterval) : 1
+        const minLimited = Math.max(raw, 1)
+        const danmuLengthLimit = useBiliStore().danmuLengthLimit
+
+        if (!danmuLengthLimit || danmuLengthLimit < 1) {
+            return minLimited
+        }
+
+        return Math.min(minLimited, danmuLengthLimit)
+    }
+
+    private formatTextMsgsByLine(msg: string, textinterval: number): string[] {
+        return msg
             .split(/\r?\n/)
             .map((line) => line.trim())
             .filter((line) => line.length > 0)
-            .map((line) => line.slice(0, this.textConfig.textinterval))
+            .map((line) => line.slice(0, textinterval))
             .filter((line) => line.length > 0)
+    }
+
+    private formatTextMsgsByStory(msg: string, textinterval: number): string[] {
+        const flattened = msg.replace(/\r?\n/g, '')
+        return this.sliceMsg(flattened, textinterval).filter((line) => line.length > 0)
     }
 
     private formatFavorites(): string[] {
@@ -133,13 +156,30 @@ class TextSpamer extends BaseModule {
         this.cleanUP()
         if (!this.roomId) return
 
-        const msgs = this.formatTextMsgsByLine()
+        const runOptions: TextRunOptions = {
+            enable: this.textConfig.enable,
+            timeinterval: this.textConfig.timeinterval,
+            textinterval: this.clampTextInterval(this.textConfig.textinterval),
+            storytellerMode: this.textConfig.storytellerMode,
+            sequentialMode: this.textConfig.sequentialMode
+        }
+
+        this.textConfig.textinterval = runOptions.textinterval
+
+        const msgs = runOptions.storytellerMode
+            ? this.formatTextMsgsByStory(this.textConfig.msg, runOptions.textinterval)
+            : this.formatTextMsgsByLine(this.textConfig.msg, runOptions.textinterval)
+
         if (msgs.length === 0) return
 
-        const timeinterval = this.formatTime(this.textConfig.timeinterval)
+        const timeinterval = this.formatTime(runOptions.timeinterval)
         const timelimit = this.formatTime(this.textConfig.timelimit)
 
-        this.createRandomSender(msgs, this.roomId, timeinterval, this.textConfig)
+        if (runOptions.sequentialMode) {
+            this.createCycleSender(msgs, this.roomId, timeinterval, this.textConfig)
+        } else {
+            this.createRandomSender(msgs, this.roomId, timeinterval, this.textConfig)
+        }
 
         if (timelimit > 0) {
             this.timeLimitId = setTimeout(() => {

--- a/src/modules/Spamer/textSpamer.ts
+++ b/src/modules/Spamer/textSpamer.ts
@@ -30,6 +30,15 @@ class TextSpamer extends BaseModule {
         return msg.match(new RegExp(`.{1,${maxLength}}`, 'g')) || []
     }
 
+    private formatTextMsgsByLine(): string[] {
+        return this.textConfig.msg
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0)
+            .map((line) => line.slice(0, this.textConfig.textinterval))
+            .filter((line) => line.length > 0)
+    }
+
     private formatFavorites(): string[] {
         return _.flatMap(this.favoritesConfig.favoritesTabPanels, (item) => {
             if (!item.msg) return []
@@ -100,16 +109,37 @@ class TextSpamer extends BaseModule {
         this.intervalId = setInterval(sendNext, timeinterval)
     }
 
+    private createRandomSender(
+        msgs: string[],
+        roomid: number,
+        timeinterval: number,
+        config: SpamConfig
+    ): void {
+        const sendNext = async () => {
+            if (!config.enable) {
+                this.cleanUP()
+                return
+            }
+
+            const randomIndex = Math.floor(Math.random() * msgs.length)
+            await this.sendMsg(msgs[randomIndex], roomid)
+        }
+
+        sendNext()
+        this.intervalId = setInterval(sendNext, timeinterval)
+    }
+
     private async startTextSpam(): Promise<void> {
         this.cleanUP()
         if (!this.roomId) return
 
-        const formattedMsg = this.formatMsg(this.textConfig.msg)
-        const msgs = this.sliceMsg(formattedMsg, this.textConfig.textinterval)
+        const msgs = this.formatTextMsgsByLine()
+        if (msgs.length === 0) return
+
         const timeinterval = this.formatTime(this.textConfig.timeinterval)
         const timelimit = this.formatTime(this.textConfig.timelimit)
 
-        this.createCycleSender(msgs, this.roomId, timeinterval, this.textConfig)
+        this.createRandomSender(msgs, this.roomId, timeinterval, this.textConfig)
 
         if (timelimit > 0) {
             this.timeLimitId = setTimeout(() => {

--- a/src/modules/Spamer/textSpamer.ts
+++ b/src/modules/Spamer/textSpamer.ts
@@ -21,6 +21,7 @@ interface FavoritesRunOptions extends SpamConfig {
     textinterval: number
     storytellerMode: boolean
     sequentialMode: boolean
+    sendingTabName: number | null
 }
 
 class TextSpamer extends BaseModule {
@@ -65,8 +66,9 @@ class TextSpamer extends BaseModule {
     }
 
     private formatFavorites(options: FavoritesRunOptions): string[] {
+        const targetTabName = options.sendingTabName ?? this.favoritesConfig.favoritesTabsValue
         const currentPanel = this.favoritesConfig.favoritesTabPanels.find(
-            (panel) => panel.name === this.favoritesConfig.favoritesTabsValue
+            (panel) => panel.name === targetTabName
         )
 
         if (!currentPanel?.msg) {
@@ -205,7 +207,8 @@ class TextSpamer extends BaseModule {
             timeinterval: this.favoritesConfig.timeinterval,
             textinterval: this.clampTextInterval(this.textConfig.textinterval),
             storytellerMode: this.favoritesConfig.storytellerMode,
-            sequentialMode: this.favoritesConfig.sequentialMode
+            sequentialMode: this.favoritesConfig.sequentialMode,
+            sendingTabName: this.favoritesConfig.sendingTabName
         }
 
         const msgs = this.formatFavorites(runOptions)
@@ -225,6 +228,9 @@ class TextSpamer extends BaseModule {
         const log = area === 'text' ? '文字独轮车已停止' : '收藏夹独轮车已停止'
 
         config.enable = false
+        if (area === 'favorites') {
+            this.favoritesConfig.sendingTabName = null
+        }
         this.cleanUP()
         this.logger.log(log)
     }
@@ -240,4 +246,3 @@ class TextSpamer extends BaseModule {
 }
 
 export default TextSpamer
-

--- a/src/modules/Spamer/textSpamer.ts
+++ b/src/modules/Spamer/textSpamer.ts
@@ -65,12 +65,17 @@ class TextSpamer extends BaseModule {
     }
 
     private formatFavorites(options: FavoritesRunOptions): string[] {
-        return _.flatMap(this.favoritesConfig.favoritesTabPanels, (item) => {
-            if (!item.msg) return []
-            return options.storytellerMode
-                ? this.formatMsgsByStory(item.msg, options.textinterval)
-                : this.formatMsgsByLine(item.msg, options.textinterval)
-        })
+        const currentPanel = this.favoritesConfig.favoritesTabPanels.find(
+            (panel) => panel.name === this.favoritesConfig.favoritesTabsValue
+        )
+
+        if (!currentPanel?.msg) {
+            return []
+        }
+
+        return options.storytellerMode
+            ? this.formatMsgsByStory(currentPanel.msg, options.textinterval)
+            : this.formatMsgsByLine(currentPanel.msg, options.textinterval)
     }
 
     private formatTime(seconds: number): number {
@@ -235,3 +240,4 @@ class TextSpamer extends BaseModule {
 }
 
 export default TextSpamer
+

--- a/src/modules/default/userInfo.ts
+++ b/src/modules/default/userInfo.ts
@@ -1,5 +1,6 @@
 import { BILIAPI } from '@/utils/bili'
 import { useBiliStore } from '../../stores/useBiliStore'
+import { useModuleStore } from '@/stores/useModuleStore'
 import { unsafeWindow } from '$'
 import BaseModule from '../BaseModule'
 import { BiliAPIResponse } from '@/types'
@@ -78,13 +79,43 @@ class UserInfo extends BaseModule {
         }
     }
 
-    public async run(): Promise<void> {
-        useBiliStore().BilibiliLive = await this.getWindowBiliLive()
-        if (useBiliStore().BilibiliLive) {
-            useBiliStore().emotionData = await this.getEmotionData()
+    private syncTextIntervalWithDanmuLimit(limit: number | null): void {
+        if (!limit || limit < 1) {
+            return
         }
-        useBiliStore().loginInfo = await this.getLoginInfo()
-        useBiliStore().infoByuser = await this.getInfoByUser()
+
+        const moduleStore = useModuleStore()
+        const currentInterval = moduleStore.moduleConfig.TextSpam.textinterval
+
+        if (currentInterval === 20 || currentInterval < 1 || currentInterval > limit) {
+            moduleStore.moduleConfig.TextSpam.textinterval = limit
+        }
+    }
+
+    public async run(): Promise<void> {
+        const biliStore = useBiliStore()
+
+        biliStore.BilibiliLive = await this.getWindowBiliLive()
+        if (biliStore.BilibiliLive) {
+            biliStore.emotionData = await this.getEmotionData()
+        }
+
+        biliStore.loginInfo = await this.getLoginInfo()
+        biliStore.infoByuser = await this.getInfoByUser()
+
+        const roomID = biliStore.BilibiliLive?.ROOMID
+        let danmuLengthLimit = biliStore.infoByuser?.property.danmu.length ?? null
+
+        if (roomID) {
+            try {
+                danmuLengthLimit = await BILIAPI.getCurrentUserDanmuLengthLimit(roomID)
+            } catch (error) {
+                this.logger.warn('获取当前用户弹幕字数上限失败，回退到 getInfoByUser', error)
+            }
+        }
+
+        biliStore.danmuLengthLimit = danmuLengthLimit
+        this.syncTextIntervalWithDanmuLimit(danmuLengthLimit)
     }
 }
 

--- a/src/stores/useBiliStore.ts
+++ b/src/stores/useBiliStore.ts
@@ -8,6 +8,8 @@ export const useBiliStore = defineStore('bili', () => {
     const emotionData = ref<BiliAPIResponse.GetEmoticons.EmoticonPackage[]>([])
     const BilibiliLive = ref<Window['BilibiliLive'] | null>(null)
     const infoByuser = ref<BiliAPIResponse.GetInfoByUser.Data | null>(null)
+    const danmuLengthLimit = ref<number | null>(null)
 
-    return { cookies, loginInfo, emotionData, BilibiliLive, infoByuser }
+    return { cookies, loginInfo, emotionData, BilibiliLive, infoByuser, danmuLengthLimit }
 })
+

--- a/src/types/BiliAPIMethods.d.ts
+++ b/src/types/BiliAPIMethods.d.ts
@@ -41,7 +41,9 @@ interface BiliAPIMethods {
         room_id: number
     ) => Promise<BiliAPIResponse.GetEmoticons.Response>
     getInfoByUser: (room_id: number) => Promise<BiliAPIResponse.GetInfoByUser.Response>
+    getCurrentUserDanmuLengthLimit: (room_id: number) => Promise<number>
     nav: () => Promise<BiliAPIResponse.Nav.Response>
 }
 
 export { BiliAPIMethods }
+

--- a/src/types/MonkeyStorage.d.ts
+++ b/src/types/MonkeyStorage.d.ts
@@ -72,3 +72,4 @@ type moduleEmitter = {
 }
 
 export { modulesConfig, uiConfig, menuIndex, moduleEmitter }
+

--- a/src/types/MonkeyStorage.d.ts
+++ b/src/types/MonkeyStorage.d.ts
@@ -22,6 +22,8 @@ interface modulesConfig {
         timeinterval: number
         favoritesTabsValue: number
         favoritesTabPanels: favoritesTabPanels[]
+        storytellerMode: boolean
+        sequentialMode: boolean
     }
 
     setting: {

--- a/src/types/MonkeyStorage.d.ts
+++ b/src/types/MonkeyStorage.d.ts
@@ -5,6 +5,8 @@ interface modulesConfig {
         timeinterval: number
         textinterval: number
         timelimit: number
+        storytellerMode: boolean
+        sequentialMode: boolean
     }
 
     EmotionSpam: {

--- a/src/utils/bili/index.ts
+++ b/src/utils/bili/index.ts
@@ -104,6 +104,12 @@ export const BILIAPI: BiliAPIMethods = {
         )
         return res.data
     },
+    getCurrentUserDanmuLengthLimit: async (room_id) => {
+        const res = await axios.get<BiliAPIResponse.GetInfoByUser.Response>(
+            `https://api.live.bilibili.com/xlive/web-room/v1/index/getInfoByUser?room_id=${room_id}`
+        )
+        return res.data.data.property.danmu.length
+    },
     nav: async () => {
         const res = await axios.get<BiliAPIResponse.Nav.Response>(
             'https://api.bilibili.com/x/web-interface/nav'
@@ -111,3 +117,7 @@ export const BILIAPI: BiliAPIMethods = {
         return res.data
     }
 }
+
+
+
+

--- a/src/utils/storage/defaultValues.ts
+++ b/src/utils/storage/defaultValues.ts
@@ -33,6 +33,8 @@ export default {
             enable: false,
             timeinterval: 5,
             favoritesTabsValue: 1,
+            storytellerMode: false,
+            sequentialMode: false,
             favoritesTabPanels: [
                 {
                     key: 1,

--- a/src/utils/storage/defaultValues.ts
+++ b/src/utils/storage/defaultValues.ts
@@ -18,7 +18,9 @@ export default {
             msg: '车',
             timeinterval: 5,
             textinterval: 20,
-            timelimit: 0
+            timelimit: 0,
+            storytellerMode: false,
+            sequentialMode: false
         },
         EmotionSpam: {
             enable: false,

--- a/src/utils/storage/defaultValues.ts
+++ b/src/utils/storage/defaultValues.ts
@@ -35,6 +35,7 @@ export default {
             favoritesTabsValue: 1,
             storytellerMode: false,
             sequentialMode: false,
+            sendingTabName: null,
             favoritesTabPanels: [
                 {
                     key: 1,


### PR DESCRIPTION
## Changes

### New Features

- 为 **文字独轮车 (TextSpam)** 增加两个发送模式：
  - 说书模式
  - 按顺序发送

- 为 **收藏夹模块 (Favorites)** 增加相同的发送模式控制：
  - 说书模式
  - 按顺序发送

### Improvements

- 新增 API：获取当前用户的弹幕长度限制
- TextSpam 发送逻辑优化：
  - 按换行拆分文本
  - 每行按 `textinterval` 截断
  - 每轮随机选择一行发送

### Bug Fix

- 修复收藏夹在切换标签后仍发送错误内容的问题
- 发送逻辑改为 **严格基于当前焦点标签页**
- 启动前校验仅检查 **当前标签页**

## Behavior

收藏夹现在：

- 始终发送当前选中的标签页内容
- 切换标签后发送内容不会错位
- 运行中修改发送模式不会立即生效，需要重新点击“开车”

## Compatibility

- 收藏夹仍复用 `textinterval`
- 未新增“数量间隔 / 时间限制”配置
- 保持原有参数结构不变

## Test

- `npm run build` 成功
- `npm run dev` 成功
- 手动测试：
  - 文字独轮车发送模式正常
  - 收藏夹切换标签发送正确
  - 顺序 / 随机发送逻辑符合预期

## Updates (added after initial PR)

### New Features & Improvements

- feat(favorites): 收藏夹仅锁定正在发送标签，支持运行中准备其他标签内容  
  - 发送内容固定为启动时选中的标签页  
  - 正在发送标签不可编辑，其他标签可编辑  
  - 停车后恢复编辑  
  - npm run build 通过，手动测试确认功能正常

- feat(preview): 新增说书模式关闭时的超长灰显预览与滚动同步  
  - 文字超长部分灰显，帮助用户识别被丢弃字符  
  - 预览区与输入框双向同步滚动  
  - 样式与原输入框一致

- fix(preview): 修复弹窗重开后预览框半截/文字偏移  
  - 使用 offsetTop/offsetLeft/offsetWidth/offsetHeight 避免 transform 干扰  
  - 增加多阶段重算机制确保预览稳定对齐

- feat(ui): 优化开关区排版、交互限制与预览提示  
  - 调整开关区排版、移除多余反馈空白  
  - 统一模式开关在运行时的交互限制  
  - 表情按钮布局调整，预览提示文案统一

- fix(ui): 恢复反馈区样式并规范模式开关标题结构  
  - 修复 show-feedback=false 导致的布局异常  
  - 模式开关新增原生 label，修复标题与开关重叠

- fix(emoji): 按光标位置插入表情并修复文本框跳尾问题
  - 优化文字独轮车 / 收藏夹表情选择器插入逻辑：
    - 不再固定追加到末尾，而是按当前光标或选区位置插入
    - 在输入框中记录并维护选区位置，确保打开表情面板后定位正确
    - 插入后自动回写光标到表情后方，连续插入体验自然
  - 修复文字独轮车中“插入表情后文本框跳到末尾”的回归问题
    - 插入后保持原滚动位置和编辑上下文

- fix(build): 避免 Tampermonkey 中收藏夹页面卡死
  - 仅在 overlay 样式值变化时写入状态，减少重复响应式更新
  - TextView / FavoritesView overlay 样式与 transform 优化
  - pnpm run build 成功生成产物，页面正常

- feat(preview): 预览超长文本改为橙色标识并同步更新提示文案
  - 文字独轮车 & 收藏夹逐行预览的超长文本高亮色由灰色调整为橙色 #F47A4D，提升深色模式可读性
  - 同步修改提示文案为：“橙色文字代表超过本行字数上限会被自动舍弃”
  - 不影响发送逻辑，仅调整视觉表达与文案一致性

- fix(text-view): 修复文字独轮车切换说书模式后预览框文字错位问题
  - 为 TextSpam.storytellerMode 增加重排监听
  - 模式切换时触发 scheduleTextRelayout，避免预览文字跑出边框

- fix(preview-copy): 优化逐行发送预览提示文案并高亮“橙色文字” 

### Test

- `npm run build` 成功
- `npm run dev` 成功

如果需要我可以继续拆分或调整提交