### PR TITLE
fix: 默认弹幕字数间隔从20更新为40

### DIFF
--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -180,7 +180,7 @@ const rules = {
                                 clearable
                                 :show-button="false"
                                 v-model:value="moduleStore.moduleConfig.TextSpam.textinterval"
-                                placeholder="默认20"
+                                placeholder="默认40"
                                 min="1"
                                 :max="biliStore.infoByuser?.property.danmu.length"
                                 :precision="0"

--- a/src/utils/storage/defaultValues.ts
+++ b/src/utils/storage/defaultValues.ts
@@ -20,7 +20,7 @@ export default {
             timeinterval: 5,
             timeintervalMax: 5,
             randomize: false,
-            textinterval: 20,
+            textinterval: 40,
             timelimit: 0
         },
         EmotionSpam: {


### PR DESCRIPTION
## Summary

- B站现已支持单条弹幕发送最多 40 字，但脚本默认的 `textinterval` 仍为 20，导致 40 字以内的消息被不必要地拆分为两段发送
- 将 `defaultValues.ts` 中 `TextSpam.textinterval` 默认值从 20 改为 40
- 将 `TextView.vue` 中输入框 placeholder 从 "默认20" 改为 "默认40"

## Changes

- `src/utils/storage/defaultValues.ts`: `textinterval: 20` → `textinterval: 40`
- `src/components/TextView.vue`: `placeholder="默认20"` → `placeholder="默认40"`

## Note

输入框的 `:max` 已动态绑定到 `biliStore.infoByuser?.property.danmu.length`（来自 B站 API），因此上限无需硬编码，未来 B站调整上限时也能自动适配。

对于已有用户，由于 `mergeConfigs` 优先使用 GM 存储中的旧值，可能需要手动在"数量间隔"输入框中将值从 20 改为 40，或清除脚本存储数据让新默认值生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)