### PR TITLE
feat: 支持换行分隔弹幕

### DIFF
--- a/src/modules/Spamer/textSpamer.ts
+++ b/src/modules/Spamer/textSpamer.ts
@@ -29,15 +29,16 @@ class TextSpamer extends BaseModule {
         return min
     }
 
-    private formatMsg(msg: string): string {
-        return msg.replace(/\n/g, '')
+    private splitLines(msg: string): string[] {
+        return msg.split('\n').filter((line) => line.length > 0)
     }
 
     private formatFavorites(): string[] {
         return _.flatMap(this.favoritesConfig.favoritesTabPanels, (item) => {
             if (!item.msg) return []
-            const processedMsg = this.formatMsg(item.msg)
-            return sliceDanmaku(processedMsg, this.textConfig.textinterval)
+            return this.splitLines(item.msg).flatMap((line) =>
+                sliceDanmaku(line, this.textConfig.textinterval)
+            )
         })
     }
 
@@ -113,8 +114,9 @@ class TextSpamer extends BaseModule {
         this.cleanUP()
         if (!this.roomId) return
 
-        const formattedMsg = this.formatMsg(this.textConfig.msg)
-        const msgs = sliceDanmaku(formattedMsg, this.textConfig.textinterval)
+        const msgs = this.splitLines(this.textConfig.msg).flatMap((line) =>
+            sliceDanmaku(line, this.textConfig.textinterval)
+        )
         const timeintervalMin = this.formatTime(this.textConfig.timeinterval)
         const timeintervalMax = this.formatTime(this.textConfig.timeintervalMax)
         const timelimit = this.formatTime(this.textConfig.timelimit)

--- a/src/utils/danmaku/index.ts
+++ b/src/utils/danmaku/index.ts
@@ -7,6 +7,7 @@ function isEmojiGrapheme(grapheme: string): boolean {
 export function getDanmakuLength(str: string): number {
     let count = 0
     for (const { segment } of graphemeSegmenter.segment(str)) {
+        if (segment === '\n') continue
         count += isEmojiGrapheme(segment) ? 2 : 1
     }
     return count


### PR DESCRIPTION
## Summary

当前脚本在输入换行文本时，会将换行符直接删除，导致无法通过换行分隔多条弹幕。本次修改将换行符作为分隔符，按行拆分为多条独立弹幕循环发送。

## Changes

- **修改** `src/modules/Spamer/textSpamer.ts`：将 `formatMsg`（删除换行）替换为 `splitLines`（按换行分割并过滤空行），`startTextSpam` 和 `formatFavorites` 均使用新逻辑，每行再按数量间隔截断
- **修改** `src/utils/danmaku/index.ts`：`getDanmakuLength` 跳过换行符，字数统计不计算换行

## Test Plan

- [x] 在文字独轮车输入含换行的文本（如 "1\n2\n3"），验证依次发送 "1", "2", "3", "1", "2", "3"...
- [x] 某行超过数量间隔时，验证该行被正确截断
- [x] 输入含连续换行或尾部换行的文本，验证空行被跳过
- [x] 收藏夹中测试同样的换行分隔场景
- [x] 不含换行的文本行为与修改前一致
- [x] 字数统计中换行符不计入

🤖 Generated with [Claude Code](https://claude.com/claude-code)