### PR TITLE
feat(spamer): 新增发送内容的搜索与替换功能

### DIFF
--- a/src/components/FavoritesView.vue
+++ b/src/components/FavoritesView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, onMounted, onUnmounted } from 'vue'
 import {
     NForm,
     NFormItem,
@@ -22,6 +22,7 @@ import { useBiliStore } from '@/stores/useBiliStore'
 import { updateSaveSpamerStatusList } from '@/utils/ui'
 import { getDanmakuLength } from '@/utils/danmaku'
 import stop from '@/modules/Spamer/textSpamer'
+import SearchReplaceWidget from './SearchReplaceWidget.vue'
 
 const moduleStore = useModuleStore()
 const uiStore = useUIStore()
@@ -153,6 +154,40 @@ const handleSendToText = () => {
         message.error('未找到当前标签页')
     }
 }
+
+const showSearchReplace = ref(false)
+const textareaInstRef = ref<any>(null)
+
+const currentPanel = computed(() => {
+    return moduleStore.moduleConfig.Favorites.favoritesTabPanels.find(
+        (panel) => panel.name === moduleStore.moduleConfig.Favorites.favoritesTabsValue
+    )
+})
+
+const currentPanelMsg = computed({
+    get: () => currentPanel.value?.msg ?? '',
+    set: (val) => {
+        if (currentPanel.value) {
+            currentPanel.value.msg = val
+        }
+    }
+})
+
+const handleKeyDown = (e: KeyboardEvent) => {
+    if (!uiStore.uiConfig.isShowPanel) return
+    if ((e.ctrlKey || e.metaKey) && (e.key === 'f' || e.key === 'F')) {
+        e.preventDefault()
+        showSearchReplace.value = true
+    }
+}
+
+onMounted(() => {
+    window.addEventListener('keydown', handleKeyDown)
+})
+
+onUnmounted(() => {
+    window.removeEventListener('keydown', handleKeyDown)
+})
 </script>
 
 <template>
@@ -250,23 +285,45 @@ const handleSendToText = () => {
                         />
                     </n-form-item>
                     <n-form-item
-                        label="发送内容"
-                        show-require-mark
+                        :show-label="false"
                         :validation-status="panels.msg === '' ? 'error' : undefined"
                     >
-                        <n-input
-                            v-model:value="panels.msg"
-                            round
-                            clearable
-                            show-count
-                            type="textarea"
-                            placeholder="默认每次弹幕发送字数为你文字独轮车设置的间隔，超出相应值将自动分割到下一条弹幕"
-                            rows="5"
-                        >
-                            <template #count="{ value }">
-                                {{ getDanmakuLength(value ?? '') }}
-                            </template>
-                        </n-input>
+                        <n-flex vertical style="width: 100%; gap: 6px;">
+                            <n-flex justify="space-between" align="center" style="width: 100%">
+                                <span style="font-weight: 500; font-size: 14px;">
+                                    <span style="color: #d03050; margin-right: 4px;">*</span>发送内容
+                                </span>
+                                <n-button
+                                    size="tiny"
+                                    type="primary"
+                                    secondary
+                                    @click="showSearchReplace = true"
+                                >
+                                    搜索替换
+                                </n-button>
+                            </n-flex>
+                            <div class="blspam-textarea-container" style="position: relative; width: 100%;">
+                                <n-input
+                                    ref="textareaInstRef"
+                                    v-model:value="panels.msg"
+                                    round
+                                    clearable
+                                    show-count
+                                    type="textarea"
+                                    placeholder="默认每次弹幕发送字数为你文字独轮车设置的间隔，超出相应值将自动分割到下一条弹幕"
+                                    rows="5"
+                                >
+                                    <template #count="{ value }">
+                                        {{ getDanmakuLength(value ?? '') }}
+                                    </template>
+                                </n-input>
+                                <SearchReplaceWidget
+                                    v-model:show="showSearchReplace"
+                                    v-model:value="currentPanelMsg"
+                                    :textarea-inst="textareaInstRef"
+                                />
+                            </div>
+                        </n-flex>
                     </n-form-item>
                 </n-tab-pane>
             </n-tabs>

--- a/src/components/SearchReplaceWidget.vue
+++ b/src/components/SearchReplaceWidget.vue
@@ -1,0 +1,465 @@
+<script setup lang="ts">
+import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import {
+    NCard,
+    NInput,
+    NInputGroup,
+    NButton,
+    NCheckbox,
+    NSpace,
+    NFlex,
+    useMessage,
+    useDialog
+} from 'naive-ui'
+
+const props = defineProps<{
+    show: boolean
+    value: string
+    textareaInst: any
+}>()
+
+const emit = defineEmits<{
+    (e: 'update:show', value: boolean): void
+    (e: 'update:value', value: string): void
+}>()
+
+const message = useMessage()
+const dialog = useDialog()
+
+const searchText = ref('')
+const replaceText = ref('')
+const caseSensitive = ref(false)
+const useRegex = ref(false)
+
+const matchRanges = ref<{ start: number; end: number }[]>([])
+const activeMatchIndex = ref(-1)
+
+const searchInputRef = ref<InstanceType<typeof NInput> | null>(null)
+const textareaEl = ref<HTMLTextAreaElement | null>(null)
+
+const getSearchRegex = (): RegExp | null => {
+    if (!searchText.value) return null
+    try {
+        const flags = 'g' + (caseSensitive.value ? '' : 'i')
+        if (useRegex.value) {
+            return new RegExp(searchText.value, flags)
+        } else {
+            const escaped = searchText.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            return new RegExp(escaped, flags)
+        }
+    } catch (e) {
+        return null
+    }
+}
+
+let debounceTimer: any = null
+const isComposing = ref(false)
+
+const triggerDebounceFocus = () => {
+    if (debounceTimer) {
+        clearTimeout(debounceTimer)
+    }
+    if (isComposing.value) return
+
+    debounceTimer = setTimeout(() => {
+        if (props.show && matchRanges.value.length > 0) {
+            activeMatchIndex.value = 0
+            highlightMatch(0, true)
+        }
+    }, 500)
+}
+
+const handleCompositionStart = () => {
+    isComposing.value = true
+}
+
+const handleCompositionEnd = () => {
+    isComposing.value = false
+    triggerDebounceFocus()
+}
+
+
+
+const handleTextareaKeyDown = (e: KeyboardEvent) => {
+    if (!props.show) return
+
+    if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        findPrev()
+    } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        findNext()
+    } else if (e.key === 'Enter') {
+        e.preventDefault()
+        findNext()
+    } else if (e.key === 'Escape') {
+        e.preventDefault()
+        searchInputRef.value?.focus()
+    } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        // 用户输入普通字符，我们把它转回查找输入框
+        e.preventDefault()
+        const inputEl = searchInputRef.value?.$el?.querySelector('input') as HTMLInputElement | null
+        if (inputEl) {
+            inputEl.focus()
+            
+            // 获取当前选区并插入字符
+            const start = inputEl.selectionStart ?? searchText.value.length
+            const end = inputEl.selectionEnd ?? searchText.value.length
+            searchText.value = searchText.value.slice(0, start) + e.key + searchText.value.slice(end)
+            
+            // 将光标设置在刚刚插入 of the character 后面
+            const newPos = start + 1
+            nextTick(() => {
+                inputEl.setSelectionRange(newPos, newPos)
+            })
+        }
+    } else if (e.key === 'Backspace') {
+        e.preventDefault()
+        const inputEl = searchInputRef.value?.$el?.querySelector('input') as HTMLInputElement | null
+        if (inputEl) {
+            inputEl.focus()
+            
+            const start = inputEl.selectionStart ?? searchText.value.length
+            const end = inputEl.selectionEnd ?? searchText.value.length
+            
+            if (start !== end) {
+                // 如果有选区，删掉选区
+                searchText.value = searchText.value.slice(0, start) + searchText.value.slice(end)
+                nextTick(() => {
+                    inputEl.setSelectionRange(start, start)
+                })
+            } else if (start > 0) {
+                // 没有选区，删掉光标前的一个字符
+                searchText.value = searchText.value.slice(0, start - 1) + searchText.value.slice(start)
+                const newPos = start - 1
+                nextTick(() => {
+                    inputEl.setSelectionRange(newPos, newPos)
+                })
+            }
+        }
+    }
+}
+
+const getTextArea = (): HTMLTextAreaElement | null => {
+    if (props.textareaInst?.$el) {
+        return props.textareaInst.$el.querySelector('textarea')
+    }
+    return null
+}
+
+const updateMatches = () => {
+    const text = props.value
+    if (!text || !searchText.value) {
+        matchRanges.value = []
+        activeMatchIndex.value = -1
+        return
+    }
+
+    const regex = getSearchRegex()
+    if (!regex) {
+        matchRanges.value = []
+        activeMatchIndex.value = -1
+        return
+    }
+
+    try {
+        const ranges: { start: number; end: number }[] = []
+        let match: RegExpExecArray | null
+        regex.lastIndex = 0
+
+        const limit = 10000
+        let count = 0
+        while ((match = regex.exec(text)) !== null && count < limit) {
+            count++
+            ranges.push({
+                start: match.index,
+                end: match.index + match[0].length
+            })
+            if (match[0].length === 0) {
+                regex.lastIndex++
+            }
+        }
+
+        matchRanges.value = ranges
+        if (activeMatchIndex.value >= ranges.length) {
+            activeMatchIndex.value = ranges.length - 1
+        }
+    } catch (e: any) {
+        matchRanges.value = []
+        activeMatchIndex.value = -1
+    }
+}
+
+const scrollTextareaToRange = (textarea: HTMLTextAreaElement, start: number) => {
+    const textBefore = textarea.value.slice(0, start)
+    const lines = textBefore.split('\n')
+    const lineNumber = lines.length - 1
+
+    const computedStyle = window.getComputedStyle(textarea)
+    const lineHeightStr = computedStyle.lineHeight
+    let lineHeight = parseFloat(lineHeightStr)
+    if (isNaN(lineHeight)) {
+        const fontSize = parseFloat(computedStyle.fontSize) || 14
+        lineHeight = fontSize * 1.5
+    }
+
+    const textareaHeight = textarea.clientHeight
+    const targetScrollTop = Math.max(0, lineNumber * lineHeight - textareaHeight / 2 + lineHeight / 2)
+    textarea.scrollTop = targetScrollTop
+}
+
+const highlightMatch = (index: number, focusTextarea = true) => {
+    if (index < 0 || index >= matchRanges.value.length) return
+    const range = matchRanges.value[index]
+    const textarea = getTextArea()
+    if (textarea) {
+        // Synchronously scroll and set range without focusing, avoiding focus theft during typing
+        scrollTextareaToRange(textarea, range.start)
+        textarea.setSelectionRange(range.start, range.end)
+
+        if (focusTextarea) {
+            textarea.focus()
+        }
+    }
+}
+
+const findNext = () => {
+    if (matchRanges.value.length === 0) return
+    activeMatchIndex.value = (activeMatchIndex.value + 1) % matchRanges.value.length
+    highlightMatch(activeMatchIndex.value)
+}
+
+const findPrev = () => {
+    if (matchRanges.value.length === 0) return
+    activeMatchIndex.value = (activeMatchIndex.value - 1 + matchRanges.value.length) % matchRanges.value.length
+    highlightMatch(activeMatchIndex.value)
+}
+
+const replaceSelected = () => {
+    if (matchRanges.value.length === 0 || activeMatchIndex.value === -1) {
+        message.warning('请先使用查找功能定位到匹配项')
+        return
+    }
+
+    const range = matchRanges.value[activeMatchIndex.value]
+    const text = props.value
+
+    const newText = text.slice(0, range.start) + replaceText.value + text.slice(range.end)
+    emit('update:value', newText)
+
+    const nextIndex = activeMatchIndex.value >= matchRanges.value.length - 1 ? 0 : activeMatchIndex.value
+
+    nextTick(() => {
+        updateMatches()
+        if (matchRanges.value.length > 0) {
+            activeMatchIndex.value = Math.min(nextIndex, matchRanges.value.length - 1)
+            highlightMatch(activeMatchIndex.value)
+        } else {
+            activeMatchIndex.value = -1
+        }
+    })
+}
+
+const replaceAll = () => {
+    if (matchRanges.value.length === 0) {
+        message.warning('没有找到可替换的匹配项')
+        return
+    }
+
+    const count = matchRanges.value.length
+
+    dialog.warning({
+        title: '全部替换确认',
+        content: `确认全部替换这 ${count} 处匹配吗？`,
+        positiveText: '确认',
+        negativeText: '取消',
+        onPositiveClick: () => {
+            let newText = props.value
+            const regex = getSearchRegex()
+            if (!regex) {
+                message.error('正则表达式无效')
+                return
+            }
+            newText = newText.replace(regex, replaceText.value)
+
+            emit('update:value', newText)
+            message.success(`成功全部替换了 ${count} 处匹配`)
+
+            nextTick(() => {
+                updateMatches()
+                activeMatchIndex.value = -1
+            })
+        }
+    })
+}
+
+watch(
+    () => props.value,
+    () => {
+        updateMatches()
+    }
+)
+
+watch([searchText, caseSensitive, useRegex], () => {
+    updateMatches()
+    if (matchRanges.value.length > 0) {
+        activeMatchIndex.value = 0
+        highlightMatch(0, false)
+        triggerDebounceFocus()
+    } else {
+        activeMatchIndex.value = -1
+        if (debounceTimer) {
+            clearTimeout(debounceTimer)
+        }
+    }
+})
+
+watch(
+    () => props.show,
+    (newVal) => {
+        if (newVal) {
+            nextTick(() => {
+                const textarea = getTextArea()
+                if (textarea) {
+                    textareaEl.value = textarea
+                    textarea.addEventListener('keydown', handleTextareaKeyDown)
+                }
+
+                searchInputRef.value?.focus()
+                updateMatches()
+                if (matchRanges.value.length > 0) {
+                    activeMatchIndex.value = 0
+                    highlightMatch(0, false)
+                    triggerDebounceFocus()
+                }
+            })
+        } else {
+            if (debounceTimer) {
+                clearTimeout(debounceTimer)
+            }
+            if (textareaEl.value) {
+                textareaEl.value.removeEventListener('keydown', handleTextareaKeyDown)
+                textareaEl.value = null
+            }
+            const textarea = getTextArea()
+            if (textarea) {
+                textarea.setSelectionRange(0, 0)
+            }
+        }
+    }
+)
+
+const handleGlobalKeyDown = (e: KeyboardEvent) => {
+    if (props.show && (e.ctrlKey || e.metaKey) && (e.key === 'f' || e.key === 'F')) {
+        e.preventDefault()
+        searchInputRef.value?.focus()
+        searchInputRef.value?.select()
+    }
+}
+
+onMounted(() => {
+    window.addEventListener('keydown', handleGlobalKeyDown)
+})
+
+onUnmounted(() => {
+    window.removeEventListener('keydown', handleGlobalKeyDown)
+    if (textareaEl.value) {
+        textareaEl.value.removeEventListener('keydown', handleTextareaKeyDown)
+    }
+    if (debounceTimer) {
+        clearTimeout(debounceTimer)
+    }
+})
+
+const handleSearchKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        findPrev()
+    } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        findNext()
+    } else if (e.key === 'Enter') {
+        e.preventDefault()
+        findNext()
+    }
+}
+</script>
+
+<template>
+    <n-card
+        v-if="show"
+        size="small"
+        closable
+        @close="emit('update:show', false)"
+        style="
+            position: absolute;
+            top: 4px;
+            right: 4px;
+            z-index: 10;
+            width: 330px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        "
+    >
+        <n-flex vertical size="small">
+            <!-- Row 1: Search -->
+            <n-input-group>
+                <n-input
+                    v-model:value="searchText"
+                    placeholder="查找"
+                    size="small"
+                    ref="searchInputRef"
+                    :input-props="{
+                        onKeydown: handleSearchKeyDown,
+                        onCompositionstart: handleCompositionStart,
+                        onCompositionend: handleCompositionEnd
+                    }"
+                    style="flex: 1"
+                />
+                <n-button size="small" @click="findPrev" title="上一个匹配">
+                    ▲
+                </n-button>
+                <n-button size="small" @click="findNext" title="下一个匹配">
+                    ▼
+                </n-button>
+            </n-input-group>
+
+            <!-- Row 2: Replace -->
+            <n-input-group>
+                <n-input
+                    v-model:value="replaceText"
+                    placeholder="替换为"
+                    size="small"
+                    style="flex: 1"
+                />
+                <n-button size="small" @click="replaceSelected" title="替换当前匹配">
+                    替换
+                </n-button>
+                <n-button size="small" type="primary" secondary @click="replaceAll" title="全部替换">
+                    全部
+                </n-button>
+            </n-input-group>
+
+            <!-- Row 3: Options & Status -->
+            <n-flex justify="space-between" align="center" style="margin-top: 2px">
+                <n-space size="small">
+                    <n-checkbox v-model:checked="caseSensitive" size="small">
+                        区分大小写
+                    </n-checkbox>
+                    <n-checkbox v-model:checked="useRegex" size="small">
+                        正则
+                    </n-checkbox>
+                </n-space>
+                <span style="font-size: 11px; color: #888;">
+                    {{ matchRanges.length > 0 ? `${activeMatchIndex + 1} / ${matchRanges.length}` : '无匹配' }}
+                </span>
+            </n-flex>
+        </n-flex>
+    </n-card>
+</template>
+
+<style>
+.blspam-textarea-container textarea::selection {
+    background: #1890ff !important;
+    color: #ffffff !important;
+}
+</style>

--- a/src/components/TextView.vue
+++ b/src/components/TextView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
 import {
     NButton,
     NForm,
@@ -20,12 +21,32 @@ import { updateSaveSpamerStatusList } from '@/utils/ui'
 import { getDanmakuLength } from '@/utils/danmaku'
 import EmotionIcon from '@/assets/EmotionIcon.svg?component'
 import stop from '@/modules/Spamer/textSpamer'
+import SearchReplaceWidget from './SearchReplaceWidget.vue'
 
 const uiStore = useUIStore()
 const moduleStore = useModuleStore()
 const biliStore = useBiliStore()
 const message = useMessage()
 const tStop = new stop('StopTextSpamer')
+
+const showSearchReplace = ref(false)
+const textareaInstRef = ref<any>(null)
+
+const handleKeyDown = (e: KeyboardEvent) => {
+    if (!uiStore.uiConfig.isShowPanel) return
+    if ((e.ctrlKey || e.metaKey) && (e.key === 'f' || e.key === 'F')) {
+        e.preventDefault()
+        showSearchReplace.value = true
+    }
+}
+
+onMounted(() => {
+    window.addEventListener('keydown', handleKeyDown)
+})
+
+onUnmounted(() => {
+    window.removeEventListener('keydown', handleKeyDown)
+})
 
 const handleStartSpamer = () => {
     if (
@@ -212,53 +233,71 @@ const rules = {
                 </n-form-item>
             </n-flex>
         </n-form-item>
-        <n-form-item label="发送内容" path="msg">
-            <n-input
-                round
-                clearable
-                type="textarea"
-                show-count
-                v-model:value="moduleStore.moduleConfig.TextSpam.msg"
-                placeholder="车了可能会被禁，但不车就等于一直被禁"
-                rows="5"
-            >
-                <template #count="{ value }">
-                    {{ getDanmakuLength(value ?? '') }}
-                </template>
-            </n-input>
-            <n-popover trigger="click" placement="left" style="width: 500px">
-                <template #trigger>
-                    <n-button text style="padding-left: 4px">
-                        <n-icon :size="24">
-                            <EmotionIcon />
-                        </n-icon>
-                    </n-button>
-                </template>
-                <div
-                    style="
-                        display: grid;
-                        grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
-                        gap: 8px;
-                        padding: 8px;
-                    "
-                >
-                    <div
-                        v-for="data in biliStore.emotionData.find((data) => data.pkg_id === 100)
-                            ?.emoticons"
-                        :key="data.emoticon_id"
-                        :disabled="data.perm === 0"
+        <n-form-item path="msg" :show-label="false">
+            <n-flex vertical style="width: 100%; gap: 6px;">
+                <n-flex justify="space-between" align="center" style="width: 100%">
+                    <span style="font-weight: 500; font-size: 14px;">发送内容</span>
+                    <n-flex align="center" style="gap: 12px;">
+                        <n-popover trigger="click" placement="bottom" style="width: 500px">
+                            <template #trigger>
+                                <n-button text style="display: flex; align-items: center;">
+                                    <n-icon :size="20">
+                                        <EmotionIcon />
+                                    </n-icon>
+                                </n-button>
+                            </template>
+                            <div
+                                style="
+                                    display: grid;
+                                    grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+                                    gap: 8px;
+                                    padding: 8px;
+                                "
+                            >
+                                <div
+                                    v-for="data in biliStore.emotionData.find((data) => data.pkg_id === 100)
+                                        ?.emoticons"
+                                    :key="data.emoticon_id"
+                                    :disabled="data.perm === 0"
+                                >
+                                    <n-avatar
+                                        :color="uiStore.uiConfig.theme === 'dark' ? '#48484E' : 'white'"
+                                        :size="24"
+                                        :src="data.url"
+                                        object-fit="contain"
+                                        style="cursor: pointer"
+                                        @click="moduleStore.moduleConfig.TextSpam.msg += data.emoji"
+                                    />
+                                </div>
+                            </div>
+                        </n-popover>
+                        <n-button size="tiny" type="primary" secondary @click="showSearchReplace = true">
+                            搜索替换
+                        </n-button>
+                    </n-flex>
+                </n-flex>
+                <div class="blspam-textarea-container" style="position: relative; width: 100%;">
+                    <n-input
+                        ref="textareaInstRef"
+                        round
+                        clearable
+                        type="textarea"
+                        show-count
+                        v-model:value="moduleStore.moduleConfig.TextSpam.msg"
+                        placeholder="车了可能会被禁，但不车就等于一直被禁"
+                        rows="5"
                     >
-                        <n-avatar
-                            :color="uiStore.uiConfig.theme === 'dark' ? '#48484E' : 'white'"
-                            :size="24"
-                            :src="data.url"
-                            object-fit="contain"
-                            style="cursor: pointer"
-                            @click="moduleStore.moduleConfig.TextSpam.msg += data.emoji"
-                        />
-                    </div>
+                        <template #count="{ value }">
+                            {{ getDanmakuLength(value ?? '') }}
+                        </template>
+                    </n-input>
+                    <SearchReplaceWidget
+                        v-model:show="showSearchReplace"
+                        v-model:value="moduleStore.moduleConfig.TextSpam.msg"
+                        :textarea-inst="textareaInstRef"
+                    />
                 </div>
-            </n-popover>
+            </n-flex>
         </n-form-item>
         <n-flex
             justify="end"


### PR DESCRIPTION
## Summary

在文字独轮车和收藏弹幕的发送内容文本框中引入“搜索与替换”悬浮面板，支持普通/区分大小写/正则的匹配查找，具备匹配项滚动定位、选中，提升弹幕管理和编辑效率。

## Changes

- **新增** `src/components/SearchReplaceWidget.vue`：独立开发文本框上方绝对定位的“搜索与替换”悬浮挂件，实现了区分大小写、正则匹配、高亮位置自动滚动定位、防抖自动聚焦以及无感键盘穿透转发机制。
- **修改** `src/components/TextView.vue`：引入 `SearchReplaceWidget` 组件，整合标题栏的表情弹窗 `<n-popover>` 和“搜索替换”按钮。
- **修改** `src/components/FavoritesView.vue`：在收藏弹幕的编辑模态框中同样整合 `SearchReplaceWidget` 组件，提供一致的搜索替换体验。

## Test Plan

- [x] 点击“搜索替换”按钮或按下 `Ctrl + F`，能正常呼出搜索替换面板，点击关闭能正常收起。
- [x] 支持普通匹配、区分大小写匹配（Aa）和正则表达式匹配（.*），能够正确高亮匹配文本，并通过上下按键/按钮切换匹配位置。
- [x] 点击“替换”能替换当前选中的匹配项，点击“全部”时弹出二次确认框，确认后替换全部匹配。例如，可以通过将“七海”全部替换“阿梓”，从而达到将“\七海/\七海/\七海/\七海/\七海/”修改为“\阿梓/\阿梓/\阿梓/\阿梓/\阿梓/”（本次PR的主要更新价值）。
- [x] 收藏夹弹窗中的搜索替换面板与主面板表现完全一致，且互不干扰。
- [x] 本地执行 `pnpm run build` 构建顺利通过，无任何编译报错。
